### PR TITLE
All the things for referral codes

### DIFF
--- a/api/controllers/TestController.js
+++ b/api/controllers/TestController.js
@@ -1,0 +1,9 @@
+/**
+ * A controller with actions that would be useful during testing and development.
+ */
+
+module.exports = {
+  ok: function(req, res) {
+    res.ok();
+  },
+}

--- a/api/controllers/WebActionsController.js
+++ b/api/controllers/WebActionsController.js
@@ -46,7 +46,8 @@ module.exports = {
 
     // Data for Mobile Commons submission
     let optInPath = 'OP4B1A27AC508266A1F4373419CE1BE391';
-    let url = 'https://secure.mcommons.com/profiles/join';
+    let url = sails.config.globals.mcJoinUrl;
+
     let data = {
       'opt_in_path[]': optInPath,
       'person[first_name]': req.body.first_name,
@@ -66,7 +67,7 @@ module.exports = {
         firstName: req.body.first_name,
         phone: req.body.phone,
         email: req.body.email,
-        // @todo referredByCode
+        referredByCode: req.body.referredByCode,
         // @todo sendGifs?
       }
     };
@@ -117,7 +118,8 @@ module.exports = {
   refer: function(req, res) {
     let optInPath = 'OP4B1A27AC508266A1F4373419CE1BE391';
     let friendsOptInPath = 'OPE8B3F738CF07CE0C3AFA3F45A5E155ED';
-    let url = 'https://secure.mcommons.com/profiles/join';
+    let url = sails.config.globals.mcJoinUrl;
+
     let data = {
       'opt_in_path[]': optInPath,
       'person[first_name]': req.body.first_name,

--- a/api/controllers/WebActionsController.js
+++ b/api/controllers/WebActionsController.js
@@ -10,6 +10,34 @@ var request = Promise.promisifyAll(require('request'));
 module.exports = {
 
   /**
+   * Forwards the referral request onto Photon.
+   *
+   * GET /referral/:phone
+   */
+  getReferralInfo: function(req, res) {
+    var baseUrl = process.env.PHOTON_URL || 'http://localhost:1338';
+    var referralRequest = {
+      method: 'GET',
+      uri: baseUrl + '/referral/' + req.params.phone,
+      json: true
+    };
+
+    request.getAsync(referralRequest)
+      .then(function(response) {
+        if (response.statusCode === 200) {
+          return res.json(response.body);
+        }
+        else {
+          return res.json(response.statusCode, response.body);
+        }
+      })
+      .catch(function(err) {
+        sails.log.error(err);
+        return res.json(500, {});
+      });
+  },
+
+  /**
    * Receives a join request and forwards it onto Mobile Commons.
    *
    * POST /join

--- a/api/controllers/WebActionsController.js
+++ b/api/controllers/WebActionsController.js
@@ -15,10 +15,9 @@ module.exports = {
    * GET /referral/:phone
    */
   getReferralInfo: function(req, res) {
-    var baseUrl = process.env.PHOTON_URL || 'http://localhost:1338';
     var referralRequest = {
       method: 'GET',
-      uri: baseUrl + '/referral/' + req.params.phone,
+      uri: sails.config.globals.photonApiUrl + '/referral/' + req.params.phone,
       json: true
     };
 
@@ -58,10 +57,9 @@ module.exports = {
     let redirectUrl = '/confirmation?phone=' + req.body.phone + '&firstName='
       + req.body.first_name;
 
-    let photonUrl = process.env.PHOTON_URL || 'http://localhost:1338';
     let photonRequest = {
       method: 'POST',
-      uri: photonUrl + '/signup',
+      uri: sails.config.globals.photonApiUrl + '/signup',
       json: true,
       body: {
         firstName: req.body.first_name,

--- a/api/controllers/WebViewController.js
+++ b/api/controllers/WebViewController.js
@@ -32,4 +32,15 @@ module.exports = {
     return res.view('confirmation', locals);
   },
 
+  /**
+   * Display the homepage view.
+   */
+  home: function(req, res) {
+    let locals = {
+      referredByCode: req.query.r
+    };
+
+    return res.view('homepage', locals);
+  },
+
 };

--- a/api/controllers/WebViewController.js
+++ b/api/controllers/WebViewController.js
@@ -13,9 +13,10 @@ module.exports = {
     let locals = {
       title: 'Confirmed! | Shine',
       layout: 'layouts/subpageCustomHeader.layout',
-      firstName: req.query.first_name ? req.query.first_name : '',
+      firstName: req.query.firstName ? req.query.firstName : '',
       phone: req.query.phone ? req.query.phone : '',
-      query: req.query
+      query: req.query,
+      referralCode: req.query.referralCode ? req.query.referralCode : ''
     };
 
     locals.headerImage = "images/confirmation-header.gif";

--- a/assets/js/refer-friend.js
+++ b/assets/js/refer-friend.js
@@ -1,0 +1,39 @@
+/**
+ * Handle request to fetch a user's referral info.
+ */
+$('#get-referral-info-btn').click(function() {
+  var phone = $('#get-referral-phone').val();
+
+  // @todo phone validation?
+  if (phone.length === 0) {
+    return;
+  }
+
+  var url = '/referral/' + phone;
+  var onSuccess = function(data) {
+    var referralUrl;
+
+    // Display the referral info section
+    $('#referral-info').show(400);
+    $('#referral-not-found').hide();
+
+    // Display results to the frontend
+    $('#referral-count').html(data.referralCount);
+    referralUrl = 'http://www.shinetext.com/?r=' + data.referralCode;
+    $('#referral-url').html(referralUrl);
+    $('#referral-url').attr('href', referralUrl);
+  };
+  var onError = function(data) {
+    $('#referral-info').hide();
+    $('#referral-not-found').show(400);
+  };
+
+  var request = {
+    url: url,
+    type: 'get',
+    success: onSuccess,
+    error: onError
+  };
+
+  $.ajax(request);
+});

--- a/assets/styles/importer.less
+++ b/assets/styles/importer.less
@@ -29,6 +29,10 @@
   @import 'pages/errors.less';
 }
 
+.refer-friend-page {
+  @import 'pages/refer-friend.less';
+}
+
 .homepage {
   @import 'pages/homepage.less';
 }

--- a/assets/styles/pages/confirmation.less
+++ b/assets/styles/pages/confirmation.less
@@ -1,22 +1,32 @@
 .header {
   text-align: center;
-}
 
-.header h1 {
-  .font-primary-bold;
+  h1 {
+    .font-primary-bold;
 
-  font-size: @font-size-header;
-  margin-bottom: @margin-sm;
+    font-size: @font-size-header;
+    margin-bottom: @margin-sm;
+  }
 }
 
 .content {
   padding: @margin-md 0;
-}
 
-.content p {
-  .font-primary;
+  h3 {
+    text-align: center;
+  }
 
-  color: @color-form-primary;
-  font-size: @font-size-normal;
-  text-align: center;
+  p {
+    .font-primary;
+
+    color: @color-form-primary;
+    font-size: @font-size-normal;
+    text-align: center;
+  }
+
+  .referral-container {
+    border-top: 1px dotted @color-form-primary;
+    margin-top: @margin-md;
+    padding-top: @margin-md;
+  }
 }

--- a/assets/styles/pages/refer-friend.less
+++ b/assets/styles/pages/refer-friend.less
@@ -1,0 +1,54 @@
+#referral-count {
+  font-size: @font-size-xl;
+  margin: @margin-sm 0;
+  text-align: center
+}
+
+#referral-info {
+  display: none;
+}
+
+#referral-not-found {
+  display: none;
+  margin: @margin-lg 0;
+}
+
+.header {
+  text-align: center;
+}
+
+.header h1 {
+  .font-primary-bold;
+
+  font-size: @font-size-header;
+  margin-bottom: @margin-sm;
+}
+
+.content {
+  padding: @margin-sm 0;
+  text-align: center;
+}
+
+.content p {
+  .font-primary;
+
+  color: black;
+  font-size: @font-size-normal;
+}
+
+.mini-form {
+  h3 {
+    margin-bottom: @margin-sm;
+  }
+
+  .-desc {
+    min-height: 85px;
+  }
+}
+
+@media (min-width: @screen-md-min) {
+  .mini-form {
+    padding: 0 @margin-lg;
+  }
+}
+

--- a/assets/styles/variables/fonts.less
+++ b/assets/styles/variables/fonts.less
@@ -32,6 +32,7 @@
   font-weight: 700;
 }
 
+@font-size-xl: 72px;
 @font-size-header: 42px;
 @font-size-title: 30px;
 @font-size-subtitle: 24px;

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -21,4 +21,9 @@ module.exports = {
   //   connection: 'someMongodbServer'
   // }
 
+  globals: {
+    // The Mobile Commons URL to send join requests to
+    mcJoinUrl: 'http://localhost:1337/mc-join',
+  },
+
 };

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -24,6 +24,9 @@ module.exports = {
   globals: {
     // The Mobile Commons URL to send join requests to
     mcJoinUrl: 'http://localhost:1337/mc-join',
+
+    // The Photon API URL
+    photonApiUrl: process.env.PHOTON_API_URL || 'http://localhost:1338',
   },
 
 };

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -35,4 +35,9 @@ module.exports = {
   //   level: "silent"
   // }
 
+  globals: {
+    // The Mobile Commons URL to send join requests to
+    mcJoinUrl: 'https://secure.mcommons.com/profiles/join',
+  },
+
 };

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -38,6 +38,9 @@ module.exports = {
   globals: {
     // The Mobile Commons URL to send join requests to
     mcJoinUrl: 'https://secure.mcommons.com/profiles/join',
+
+    // The Photon API URL
+    photonApiUrl: process.env.PHOTON_API_URL,
   },
 
 };

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -1,0 +1,10 @@
+/**
+ * Test environment settings.
+ */
+
+module.exports = {
+  globals: {
+    // The Mobile Commons URL to send join requests to
+    mcJoinUrl: 'http://localhost:1337/mc-join',
+  },
+};

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -6,5 +6,8 @@ module.exports = {
   globals: {
     // The Mobile Commons URL to send join requests to
     mcJoinUrl: 'http://localhost:1337/mc-join',
+
+    // The Photon API URL
+    photonApiUrl: 'http://localhost:1338',
   },
 };

--- a/config/routes.js
+++ b/config/routes.js
@@ -63,7 +63,7 @@ module.exports.routes = {
   },
 
   '/refer-a-friend': {
-    view: 'confirmation',
+    view: 'refer-friend',
     locals: {
       title: 'Refer a Friend | Shine',
       layout: 'layouts/subpageCustomHeader.layout',
@@ -87,6 +87,7 @@ module.exports.routes = {
   *                                                                          *
   ***************************************************************************/
 
+  'get /referral/:phone': 'WebActionsController.getReferralInfo',
   'post /join': 'WebActionsController.join',
   'post /refer': 'WebActionsController.refer',
 };

--- a/config/routes.js
+++ b/config/routes.js
@@ -20,7 +20,7 @@
  * http://sailsjs.org/#!/documentation/concepts/Routes/RouteTargetSyntax.html
  */
 
-module.exports.routes = {
+var routes = {
 
   /***************************************************************************
   *                                                                          *
@@ -32,9 +32,7 @@ module.exports.routes = {
   *                                                                          *
   ***************************************************************************/
 
-  '/': {
-    view: 'homepage'
-  },
+  '/': 'WebViewController.home',
 
   '/confirmation': 'WebViewController.confirmation',
 
@@ -91,3 +89,12 @@ module.exports.routes = {
   'post /join': 'WebActionsController.join',
   'post /refer': 'WebActionsController.refer',
 };
+
+/**
+ * Routes that should not exist on production can go here.
+ */
+if (process.env.NODE_ENV !== 'production') {
+  routes['post /mc-join'] = 'TestController.ok';
+}
+
+module.exports.routes = routes;

--- a/views/confirmation.ejs
+++ b/views/confirmation.ejs
@@ -20,10 +20,9 @@
       <div class="referral-container col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 col-md-4 col-md-offset-4">
         <h3>Your Referral Link</h3>
         <p>
-          Here's your unique referral link:<br>
+          Here's your unique referral link!<br>
           <a href="http://www.shinetext.com/?r=<%= referralCode %>" href="" id="referral-url" target="_blank">http://www.shinetext.com/?r=<%= referralCode %></a>
         </p>
-        <p>Use this link to share and get credits.</p>
       </div>
       <% } %>
 

--- a/views/confirmation.ejs
+++ b/views/confirmation.ejs
@@ -16,6 +16,17 @@
         <p><%= bodyText %></p>
       </div>
 
+      <% if (referralCode.length > 0) { %>
+      <div class="referral-container col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 col-md-4 col-md-offset-4">
+        <h3>Your Referral Link</h3>
+        <p>
+          Here's your unique referral link:<br>
+          <a href="http://www.shinetext.com/?r=<%= referralCode %>" href="" id="referral-url" target="_blank">http://www.shinetext.com/?r=<%= referralCode %></a>
+        </p>
+        <p>Use this link to share and get credits.</p>
+      </div>
+      <% } %>
+
       <%- partial ('partials/referral-form.ejs') %>
     </div>
   </div>

--- a/views/homepage.ejs
+++ b/views/homepage.ejs
@@ -30,6 +30,11 @@
       </div>
       <div class="row">
         <form action="/join" method="post">
+
+          <% if (referredByCode) { %>
+          <input name="referredByCode" value="<%= referredByCode %>" type="hidden"/>
+          <% } %>
+
           <div class="form-field">
             <input class="form-control" name="first_name" id="form-first-name" type="text" required value="">
             <label for="form-first-name">First Name</label>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -42,6 +42,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
 
     <!--SCRIPTS-->
+    <script src="/js/refer-friend.js"></script>
     <script src="/js/signup-form.js"></script>
     <!--SCRIPTS END-->
   </body>

--- a/views/layouts/subpage.layout.ejs
+++ b/views/layouts/subpage.layout.ejs
@@ -46,6 +46,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
 
     <!--SCRIPTS-->
+    <script src="/js/refer-friend.js"></script>
     <script src="/js/signup-form.js"></script>
     <!--SCRIPTS END-->
   </body>

--- a/views/layouts/subpageCustomHeader.layout.ejs
+++ b/views/layouts/subpageCustomHeader.layout.ejs
@@ -41,6 +41,7 @@
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/js/bootstrap.min.js" integrity="sha384-0mSbJDEHialfmuBBQP6A4Qrprq5OVfW37PRR3j5ELqxss1yVqOtnepnHVP9aJ7xS" crossorigin="anonymous"></script>
 
     <!--SCRIPTS-->
+    <script src="/js/refer-friend.js"></script>
     <script src="/js/signup-form.js"></script>
     <!--SCRIPTS END-->
   </body>

--- a/views/partials/referral-form.ejs
+++ b/views/partials/referral-form.ejs
@@ -4,7 +4,7 @@
 %>
 
 <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 col-md-4 col-md-offset-4">
-  <h3>Invite People Now</h3>
+  <h3><% if (referralCode.length > 0) { %>Or <% } %>Invite People Now</h3>
   <p>You can use this form to send a text message inviting your friends to Shine.</p>
   <form action="/refer" method="post">
     <div class="form-field">

--- a/views/partials/referral-form.ejs
+++ b/views/partials/referral-form.ejs
@@ -4,6 +4,8 @@
 %>
 
 <div class="col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-3 col-md-4 col-md-offset-4">
+  <h3>Invite People Now</h3>
+  <p>You can use this form to send a text message inviting your friends to Shine.</p>
   <form action="/refer" method="post">
     <div class="form-field">
       <input class="form-control" name="first_name" id="form-first-name" type="text" value="<%= fname %>" required>

--- a/views/refer-friend.ejs
+++ b/views/refer-friend.ejs
@@ -1,18 +1,73 @@
-<header class="header-confirmation">
+<div class="refer-friend-page">
+
+<div class="header">
 
   <%- partial ('partials/header-icon.ejs') %>
 
   <h1><%= headerText %></h1>
 
-</header>
-<div class="page-confirmation">
+</div>
+<div class="content">
   <div class="container">
+
     <div class="row">
-      <div class="col-xs-8 col-xs-offset-2">
-        <p><%= bodyText %></p>
+      <div class="mini-form col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-0">
+        <h3>Get Your Referral Link</h3>
+        <p class="-desc">See how many times you've brought Shine into someone's life.</p>
+
+        <div class="form-field">
+          <input class="form-control" name="get-referral-phone" id="get-referral-phone" type="text" value="">
+          <label for="get-referral-phone">Your Phone Number</label>
+        </div>
+        <div id="referral-info">
+          <div id="referral-count">0</div>
+          <p>
+            Here's your unique referral link:<br>
+            <a href="/" id="referral-url" target="_blank"></a>
+          </p>
+          <p>Use this link to share and get credits.</p>
+        </div>
+        <div id="referral-not-found">
+          <p>Sorry. We couldn't find any information for that number. Make sure
+          you're first <a href="/">signed up</a>!</p>
+        </div>
+        <div id="get-referral-info-btn" class="btn">GET MY LINK</div>
       </div>
 
-      <%- partial ('partials/referral-form.ejs') %>
-    </div>
+      <div class="mini-form col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-0">
+        <h3>Invite Your Friends Now</h3>
+        <p class="-desc">Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet. Lorem ipsum
+        dolor sit amet. Lorem ipsum dolor sit amet.</p>
+
+        <form action="/refer" method="post">
+          <div class="form-field">
+            <input class="form-control" name="first_name" id="form-first-name" type="text" value="" required>
+            <label for="form-first-name">Your First Name</label>
+            <span class="required-asterisk">*</span>
+          </div>
+
+          <div class="form-field">
+            <input class="form-control" name="phone" id="form-phone-number" type="tel" value="" required>
+            <label for="form-phone-number">Your Phone Number</label>
+            <span class="required-asterisk">*</span>
+          </div>
+
+          <div class="form-field">
+            <input class="form-control" name="friends[]" id="form-friend-1" type="tel" value="" required>
+            <label for="form-friend-1">Your Friend's Number</label>
+            <span class="required-asterisk">*</span>
+          </div>
+
+          <input class="btn" type="submit" value="SEND THEM SHINE"/>
+
+          <div class="ctia">
+            Terms and Conditions may apply. By clicking "Sign Up" you
+            are agreeing to allow Shine to send you text messages! YAY!
+          </div>
+        </form>
+      </div>
+
   </div>
+</div>
+
 </div>

--- a/views/refer-friend.ejs
+++ b/views/refer-friend.ejs
@@ -36,8 +36,8 @@
 
       <div class="mini-form col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-0">
         <h3>Invite Your Friends Now</h3>
-        <p class="-desc">Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet. Lorem ipsum
-        dolor sit amet. Lorem ipsum dolor sit amet.</p>
+        <p class="-desc">You can use this form to send a text message inviting
+        your friends to Shine.</p>
 
         <form action="/refer" method="post">
           <div class="form-field">

--- a/views/refer-friend.ejs
+++ b/views/refer-friend.ejs
@@ -13,19 +13,21 @@
     <div class="row">
       <div class="mini-form col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-0">
         <h3>Get Your Referral Link</h3>
-        <p class="-desc">See how many times you've brought Shine into someone's life.</p>
+        <p class="-desc">Get your unique code and see how many times
+        you've brought Shine into someone's life.</p>
 
         <div class="form-field">
           <input class="form-control" name="get-referral-phone" id="get-referral-phone" type="text" value="">
           <label for="get-referral-phone">Your Phone Number</label>
         </div>
         <div id="referral-info">
+          <p>You've referred this many people:</p>
           <div id="referral-count">0</div>
           <p>
-            Here's your unique referral link:<br>
+            And here's your unique referral link!<br>
             <a href="/" id="referral-url" target="_blank"></a>
+            <p>Share this to earn exclusive <strong>Shine swag</strong>.
           </p>
-          <p>Use this link to share and get credits.</p>
         </div>
         <div id="referral-not-found">
           <p>Sorry. We couldn't find any information for that number. Make sure
@@ -35,9 +37,11 @@
       </div>
 
       <div class="mini-form col-xs-10 col-xs-offset-1 col-sm-6 col-sm-offset-0">
-        <h3>Invite Your Friends Now</h3>
-        <p class="-desc">You can use this form to send a text message inviting
-        your friends to Shine.</p>
+        <h3>Or Invite Your Friends Now</h3>
+        <p class="-desc">
+          Sign up with your besties to earn exclusive <strong>Shine swag</strong>
+          that you can rock with your squad.
+        </p>
 
         <form action="/refer" method="post">
           <div class="form-field">


### PR DESCRIPTION
- Updates the /join endpoint to also submit the signup to Photon
- Updates the refer-a-friend page to query for referral info
- Updates the confirmation page to display a user's referral link if successfully received from Photon
- Updates the homepage to add a hidden input to the join submission form if a referredByCode is present in the query parms

Unrelated to referral codes:
- There's also now a TestController to put API actions that shouldn't be available in production. For now it just has a `POST /mc-join` endpoint that we'll use in place of actual Mobile Commons join submissions.