### PR TITLE
Add intention setting fields to signup form

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+#### What's this PR do?
+A summary of what this does
+
+#### How was this/how should this be reviewed?
+Whatever makes the most sense here. Call out specific implementation details that could be questionable. Is there additional context that needs to be provided. Specific commands to run to test or unit tests to watch out for.
+
+#### What are the relevant tickets?
+Closes #1
+Fixes #2
+or reference other tickets that might are related
+
+#### Questions/Considerations
+Can be for asking questions around other parts of the ecosystem that might be affected, etc. Or things to think about when deploying. Like does something else need to happen first.

--- a/api/controllers/WebActionsController.js
+++ b/api/controllers/WebActionsController.js
@@ -232,10 +232,6 @@ module.exports = {
       updateRequest.form.intention_category = req.body['intention-category'];
     }
 
-    if (req.body['intention-focus']) {
-      updateRequest.form.intention_focus = req.body['intention-focus'];
-    }
-
     request
       .postAsync(updateRequest)
       .then(response => {

--- a/api/controllers/WebActionsController.js
+++ b/api/controllers/WebActionsController.js
@@ -215,6 +215,14 @@ module.exports = {
     if (req.body['pref-time']) {
       updateRequest.form.pref_time = req.body['pref-time'];
     }
+    
+    if (req.body['intention-category']) {
+      updateRequest.form.intention_category = req.body['intention-category'];
+    }
+    
+    if (req.body['intention-focus']) {
+      updateRequest.form.intention_focus = req.body['intention-focus'];
+    }
 
     request.postAsync(updateRequest)
       .then(response => {

--- a/api/controllers/WebActionsController.js
+++ b/api/controllers/WebActionsController.js
@@ -16,9 +16,9 @@ const ReferralCodes = require('@jonuy/referral-codes');
 module.exports = {
   /**
    * Mobile Commons opt-in path to send on sign up.
-   * https://secure.mcommons.com/campaigns/147689/opt_in_paths/222196
+   * https://secure.mcommons.com/campaigns/147689/opt_in_paths/238199
    */
-  MOBILE_COMMONS_OPTIN: 'OPB1AA249928CF5621FE3CA64715CB1B44',
+  MOBILE_COMMONS_OPTIN: 'OP6E1417180DF0BC96A90BDD01B5E4E1C3',
 
   /**
    * Mobile Commons SMS sent to people who are sending a referral invite.

--- a/api/controllers/WebActionsController.js
+++ b/api/controllers/WebActionsController.js
@@ -14,7 +14,6 @@ if (process.env.MIXPANEL_TOKEN) {
 const ReferralCodes = require('@jonuy/referral-codes');
 
 module.exports = {
-
   /**
    * Mobile Commons opt-in path to send on sign up.
    * https://secure.mcommons.com/campaigns/147689/opt_in_paths/222196
@@ -44,10 +43,12 @@ module.exports = {
         'person[first_name]': req.body.first_name,
         'person[phone]': req.body.phone,
         'person[email]': req.body.email,
-        'person[send_gifs]': typeof req.body.send_gifs === 'undefined' ? 'no' : 'yes',
+        'person[send_gifs]': typeof req.body.send_gifs === 'undefined'
+          ? 'no'
+          : 'yes',
         'person[referral_code]': ReferralCodes.encode(req.body.phone),
-        'person[date_signed_up]': (new Date()).toISOString(),
-      }
+        'person[date_signed_up]': new Date().toISOString(),
+      },
     };
   },
 
@@ -69,23 +70,28 @@ module.exports = {
         email: req.body.email,
         referredByCode: req.body.referredByCode,
         // @todo sendGifs?
-      }
+      },
     };
 
-    const joinByReferral = typeof req.body.referredByCode === 'string' && req.body.referredByCode.length > 0;
+    const joinByReferral =
+      typeof req.body.referredByCode === 'string' &&
+      req.body.referredByCode.length > 0;
 
     // Flag indicating the subscription to Mobile Commons was successful
     let mcSubscribeSuccessful = false;
 
     // Make the Mobile Commons submission
-    request.postAsync(sails.config.globals.mcJoinUrl, this.createMobileCommonsRequest(req))
+    request
+      .postAsync(
+        sails.config.globals.mcJoinUrl,
+        this.createMobileCommonsRequest(req)
+      )
       .then(function(response) {
         // Mobile Commons responds with a 500 error code for numbers from
         // countries that are not supported by the account.
         if (response.statusCode == 500) {
           throw new ErrorMobileCommonsJoin(response.body);
-        }
-        else if (response.statusCode !== 200) {
+        } else if (response.statusCode !== 200) {
           throw new Error();
         }
 
@@ -123,18 +129,22 @@ module.exports = {
             },
           };
 
-          request.postAsync(mailchimpRequest)
-            .then((response) => {
-              if (! response || ! response.body) {
-                sails.log.error('Invalid response received from MailChimp subscribe call.');
-              }
-              else {
+          request
+            .postAsync(mailchimpRequest)
+            .then(response => {
+              if (!response || !response.body) {
+                sails.log.error(
+                  'Invalid response received from MailChimp subscribe call.'
+                );
+              } else {
                 sails.log.info('Successful MailChimp subscribe');
                 sails.log.info(`  id: ${response.body.id}`);
-                sails.log.info(`  unique_email_id: ${response.body.unique_email_id}`);
+                sails.log.info(
+                  `  unique_email_id: ${response.body.unique_email_id}`
+                );
               }
             })
-            .catch((err) => {
+            .catch(err => {
               sails.log.error(err);
             });
         }
@@ -174,12 +184,10 @@ module.exports = {
         // Commons subscription was successful.
         if (mcSubscribeSuccessful) {
           return res.redirect(redirectUrl);
-        }
-        else {
+        } else {
           return res.redirect(500);
         }
       });
-
   },
 
   /**
@@ -189,7 +197,11 @@ module.exports = {
    */
   saveSettings: function(req, res) {
     let birthday = '';
-    if (req.body['bday-month'] && req.body['bday-day'] && req.body['bday-year']) {
+    if (
+      req.body['bday-month'] &&
+      req.body['bday-day'] &&
+      req.body['bday-year']
+    ) {
       birthday = `${req.body['bday-year']}-${req.body['bday-month']}-${req.body['bday-day']}`;
     }
 
@@ -215,16 +227,17 @@ module.exports = {
     if (req.body['pref-time']) {
       updateRequest.form.pref_time = req.body['pref-time'];
     }
-    
+
     if (req.body['intention-category']) {
       updateRequest.form.intention_category = req.body['intention-category'];
     }
-    
+
     if (req.body['intention-focus']) {
       updateRequest.form.intention_focus = req.body['intention-focus'];
     }
 
-    request.postAsync(updateRequest)
+    request
+      .postAsync(updateRequest)
       .then(response => {
         let redirectUrl = `/confirmation?phone=${req.body.phone}&firstName=${req.body.firstName}&referralCode=${req.body.referralCode}`;
         res.redirect(redirectUrl);
@@ -246,24 +259,29 @@ module.exports = {
       form: {
         'opt_in_path[]': this.MOBILE_COMMONS_INVITE_ALPHA_OPTIN,
         'person[phone]': req.body.phone,
-        'friends_opt_in_path': this.MOBILE_COMMONS_INVITE_BETA_OPTIN,
+        friends_opt_in_path: this.MOBILE_COMMONS_INVITE_BETA_OPTIN,
       },
     };
 
     let numFriends = 0;
-    const friends = [req.body.invitePhone1, req.body.invitePhone2, req.body.invitePhone3];
+    const friends = [
+      req.body.invitePhone1,
+      req.body.invitePhone2,
+      req.body.invitePhone3,
+    ];
     for (const friend of friends) {
       if (friend) {
         data.form[`friends[${numFriends}]`] = friend;
-        data.form[`friends[${numFriends}][referral_code]`] = ReferralCodes.encode(friend);
+        data.form[
+          `friends[${numFriends}][referral_code]`
+        ] = ReferralCodes.encode(friend);
         numFriends++;
       }
     }
 
     if (numFriends === 0) {
       return false;
-    }
-    else {
+    } else {
       return data;
     }
   },
@@ -276,16 +294,16 @@ module.exports = {
   smsInvite: function(req, res) {
     const data = this.createMobileCommonsReferralRequest(req);
 
-    if (! data) {
-      return res.json(400, {status: 'No referral phone numbers provided'});
+    if (!data) {
+      return res.json(400, { status: 'No referral phone numbers provided' });
     }
 
-    request.postAsync(sails.config.globals.mcJoinUrl, data)
+    request
+      .postAsync(sails.config.globals.mcJoinUrl, data)
       .then(response => {
         if (response.statusCode === 200) {
-          return res.json(200, {status: 'ok'});
-        }
-        else {
+          return res.json(200, { status: 'ok' });
+        } else {
           return res.json(response.statusCode, {
             error: 'Error sending referral invites',
           });
@@ -298,7 +316,6 @@ module.exports = {
         });
       });
   },
-
 };
 
 /**

--- a/assets/styles/pages/sms-settings.less
+++ b/assets/styles/pages/sms-settings.less
@@ -48,13 +48,20 @@ fieldset {
 
   .input-container {
     float: right;
+    
+    .width-md {
+      max-width: 550px;
+    }
+    
+    .width-sm {
+      max-width: 100px;
+    }
 
     input {
       border: 2px solid @color-yellow;
       border-radius: 0;
       font-size: 18px;
       font-weight: 700;
-      max-width: 100px;
       padding: 10px;
     }
 
@@ -72,7 +79,7 @@ fieldset {
       cursor: pointer;
       font-size: 18px;
       font-weight: 700;
-      padding: 10px 40px 10px 10px;
+      padding: 10px 45px 10px 10px;
     }
   }
 

--- a/assets/styles/pages/sms-settings.less
+++ b/assets/styles/pages/sms-settings.less
@@ -49,19 +49,12 @@ fieldset {
   .input-container {
     float: right;
     
-    .width-md {
-      max-width: 550px;
-    }
-    
-    .width-sm {
-      max-width: 100px;
-    }
-
     input {
       border: 2px solid @color-yellow;
       border-radius: 0;
       font-size: 18px;
       font-weight: 700;
+      max-width: 100px;
       padding: 10px;
     }
 

--- a/views/sms-settings.ejs
+++ b/views/sms-settings.ejs
@@ -61,7 +61,7 @@
         <p>This will help us lock in your timezone.</p>
       </div>
       <div class="input-container">
-        <input name="zipcode" type="text" maxlength="5" />
+        <input class="width-sm" name="zipcode" type="text" maxlength="5" />
       </div>
     </fieldset>
 
@@ -88,6 +88,32 @@
         </select>
         <select id="bday-day" name="bday-day"></select>
         <select id="bday-year" name="bday-year"></select>
+      </div>
+    </fieldset>
+    
+    <fieldset>
+      <div class="label-container">
+        <label>What's one thing you want to work on most?</label>
+        <p>Focusing on ONE area is key.</p>
+      </div>
+      <div class="input-container">
+        <select id="intention-category" name="intention-category">
+          <option value="presence" selected="selected">Joy & Presence</option>
+          <option value="body">Health</option>
+          <option value="confidence">Confidence</option>
+          <option value="productivity">Productivity</option>
+          <option value="creativity">Creativity</option>
+        </select>
+      </div>
+    </fieldset>
+    
+    <fieldset>
+      <div class="label-container">
+        <label>In less than 5 words, get specific on your intention.</label>
+        <p>Avoid words like 'stop' or 'quit'.</p>
+      </div>
+      <div class="input-container">
+        <input class="width-md" name="intention-focus" type="text" />
       </div>
     </fieldset>
 

--- a/views/sms-settings.ejs
+++ b/views/sms-settings.ejs
@@ -15,7 +15,7 @@
     <fieldset>
       <div class="label-container">
         <label>What's one area you could use the most support with?</label>
-        <p>Focusing on ONE area is key.</p>
+        <p>(We call this your 'intention' and will give you a different action you can take to work on it each day)</p>
       </div>
       <div class="input-container">
         <select id="intention-category" name="intention-category">

--- a/views/sms-settings.ejs
+++ b/views/sms-settings.ejs
@@ -15,7 +15,7 @@
     <fieldset>
       <div class="label-container">
         <label>What's one area you could use the most support with?</label>
-        <p>(We call this your 'intention' and will give you a different action you can take to work on it each day)</p>
+        <p>We call this your 'intention' and will give you a different action you can take to work on it each day</p>
       </div>
       <div class="input-container">
         <select id="intention-category" name="intention-category">

--- a/views/sms-settings.ejs
+++ b/views/sms-settings.ejs
@@ -14,6 +14,22 @@
 
     <fieldset>
       <div class="label-container">
+        <label>What's one area you could use the most support with?</label>
+        <p>Focusing on ONE area is key.</p>
+      </div>
+      <div class="input-container">
+        <select id="intention-category" name="intention-category">
+          <option value="presence" selected="selected">Joy & Presence</option>
+          <option value="body">Health</option>
+          <option value="confidence">Confidence</option>
+          <option value="productivity">Productivity</option>
+          <option value="creativity">Creativity</option>
+        </select>
+      </div>
+    </fieldset>
+    
+    <fieldset>
+      <div class="label-container">
         <label>When do you want to get your daily text?</label>
         <p>Most prefer it with their morning coffee.</p>
       </div>
@@ -61,7 +77,7 @@
         <p>This will help us lock in your timezone.</p>
       </div>
       <div class="input-container">
-        <input class="width-sm" name="zipcode" type="text" maxlength="5" />
+        <input name="zipcode" type="text" maxlength="5" />
       </div>
     </fieldset>
 
@@ -91,31 +107,7 @@
       </div>
     </fieldset>
     
-    <fieldset>
-      <div class="label-container">
-        <label>What's one thing you want to work on most?</label>
-        <p>Focusing on ONE area is key.</p>
-      </div>
-      <div class="input-container">
-        <select id="intention-category" name="intention-category">
-          <option value="presence" selected="selected">Joy & Presence</option>
-          <option value="body">Health</option>
-          <option value="confidence">Confidence</option>
-          <option value="productivity">Productivity</option>
-          <option value="creativity">Creativity</option>
-        </select>
-      </div>
-    </fieldset>
     
-    <fieldset>
-      <div class="label-container">
-        <label>In less than 5 words, get specific on your intention.</label>
-        <p>Avoid words like 'stop' or 'quit'.</p>
-      </div>
-      <div class="input-container">
-        <input class="width-md" name="intention-focus" type="text" />
-      </div>
-    </fieldset>
 
     <input name="firstName" value="<%= user.firstName %>" type="hidden" />
     <input name="phone" value="<%= user.phone %>" type="hidden" />


### PR DESCRIPTION
#### What's this PR do?
- Adds 2 new form fields for intention setting (category & focus) on 2nd part of sign up form.
- Applies prettier.js code formatting and adds Github PR template to repo


#### How was this/how should this be reviewed?
- Tested manually in local env using node-inspector and browser. Will want to check that
1.) that the user profile is being updated in Mobile Commons with intention info (is there a dev 
2.) our user db is getting the intention data from MC within 10 mins 
(assuming MC and lightbeam is set up to support our pre-prod sign ups?)

#### What are the relevant tickets?
Closes #93 

#### Questions/Considerations
See code comments