### PR TITLE
Adds Mixpanel track for utm_campaign and utm_content

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+#### What's this PR do?
+A summary
+
+#### How was this tested? How should this be reviewed?
+Specific things to look out for or test
+
+#### What are the relevant tickets?
+Relevant Github issues
+
+#### Questions / Considerations
+Additional context needed or things to consider

--- a/api/controllers/WebViewController.js
+++ b/api/controllers/WebViewController.js
@@ -8,7 +8,6 @@ var Promise = require('bluebird');
 var request = Promise.promisifyAll(require('request'));
 
 module.exports = {
-
   ////////////////////////////// Redirects ///////////////////////////////////
 
   /**
@@ -73,6 +72,8 @@ module.exports = {
     let locals = {
       adviceBaseUrl: sails.config.globals.adviceBaseUrl,
       referredByCode: req.query.r,
+      utmCampaign: req.query.utm_campaign,
+      utmContent: req.query.utm_content,
       utmSource: req.query.utm_source,
       utmMedium: req.query.utm_medium,
       view: 'homepage',
@@ -86,11 +87,13 @@ module.exports = {
    */
   myReferral: function(req, res) {
     const _this = this;
-    Promise.coroutine(function* () {
+    Promise.coroutine(function*() {
       let referralRequest = {
         method: 'GET',
-        uri: sails.config.globals.photonApiUrl + '/referral/' + req.params.phone,
-        json: true
+        uri: sails.config.globals.photonApiUrl +
+          '/referral/' +
+          req.params.phone,
+        json: true,
       };
 
       try {
@@ -106,28 +109,28 @@ module.exports = {
 
         if (response.statusCode === 200) {
           locals.referralInfo = response.body;
-          locals.referralInfo.nextLevel = ReferralService.getNextLevel(response.body.referralCount);
+          locals.referralInfo.nextLevel = ReferralService.getNextLevel(
+            response.body.referralCount
+          );
 
           // @todo Not sure if this is should be the final solution for handling this
           if (locals.referralInfo.nextLevel.reward === 'Shine sticker') {
             locals.referralInfo.rewardImage = 'reward-image-1';
-          }
-          else if (locals.referralInfo.nextLevel.reward === 'Shine tote') {
+          } else if (locals.referralInfo.nextLevel.reward === 'Shine tote') {
             locals.referralInfo.rewardImage = 'reward-image-2';
-          }
-          else if (locals.referralInfo.nextLevel.reward === 'Shine t-shirt') {
+          } else if (locals.referralInfo.nextLevel.reward === 'Shine t-shirt') {
             locals.referralInfo.rewardImage = 'reward-image-3';
-          }
-          else if (locals.referralInfo.nextLevel.reward === 'Shine call-out') {
+          } else if (
+            locals.referralInfo.nextLevel.reward === 'Shine call-out'
+          ) {
             locals.referralInfo.rewardImage = 'reward-image-4';
-          }
-          else if (locals.referralInfo.nextLevel.reward === 'Shine hoodie') {
+          } else if (locals.referralInfo.nextLevel.reward === 'Shine hoodie') {
             locals.referralInfo.rewardImage = 'reward-image-5';
-          }
-          else if (locals.referralInfo.nextLevel.reward === 'Shine leggings') {
+          } else if (
+            locals.referralInfo.nextLevel.reward === 'Shine leggings'
+          ) {
             locals.referralInfo.rewardImage = 'reward-image-6';
-          }
-          else {
+          } else {
             locals.referralInfo.rewardImage = 'reward-image-6';
           }
 
@@ -136,8 +139,7 @@ module.exports = {
         }
 
         return res.view('my-referrals', locals);
-      }
-      catch(err) {
+      } catch (err) {
         sails.log.error(err);
         return res.view(500);
       }
@@ -179,6 +181,5 @@ module.exports = {
       sms: `sms:?&body=${shareBody} ${shareUrl}`,
       twitter: `http://twitter.com/intent/tweet?url=${shareUrl}&text=${shareBody}&via=ShineText`,
     };
-  }
-
+  },
 };

--- a/views/homepage.ejs
+++ b/views/homepage.ejs
@@ -43,6 +43,8 @@
       <form action="/join" method="post">
 
         <% if (referredByCode) { %><input name="referredByCode" value="<%= referredByCode %>" type="hidden"/><% } %>
+        <% if (utmCampaign) { %><input name="utmCampaign" value="<%= utmCampaign %>" type="hidden"/><% } %>
+        <% if (utmContent) { %><input name="utmContent" value="<%= utmContent %>" type="hidden"/><% } %>
         <% if (utmSource) { %><input name="utmSource" value="<%= utmSource %>" type="hidden"/><% } %>
         <% if (utmMedium) { %><input name="utmMedium" value="<%= utmMedium %>" type="hidden"/><% } %>
 


### PR DESCRIPTION
#### What's this PR do?
Sign Up events tracked in Mixpanel will now also include the `utm_campaign` and `utm_content` properties if they're found in the URL. We'd previously already tracked `utm_source` and `utm_medium`.

All other changes is just Prettier auto-formatting doing its work.

#### How was this tested?
This was tested against the dev Mixpanel project and verifying the properties of events in its Live View.

#### What are the relevant tickets?
Closes #95 

cc: @kaladin9017 