### PR TITLE
Move babel presets into dependencies of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "description": "",
   "keywords": [],
   "dependencies": {
+    "babel-preset-env": "^1.5.2",
+    "babel-preset-react": "^6.24.1",
     "@jonuy/referral-codes": "1.1.0",
     "bluebird": "^3.4.1",
     "dotenv": "^2.0.0",
@@ -39,8 +41,6 @@
   },
   "main": "app.js",
   "devDependencies": {
-    "babel-cli": "^6.24.1",
-    "babel-preset-env": "^1.5.2",
-    "babel-preset-react": "^6.24.1"
+    "babel-cli": "^6.24.1"
   }
 }


### PR DESCRIPTION
#### What's this PR do?
- Fixes app failure due to missing babel presets.
- Babel presets (`env` and `react`) were moved from package.json's `devDependencies` to `dependencies` so that they get installed as part of build step

#### How was this tested? How should this be reviewed?
Will be tested using Heroku's Deploy Preview App feature for this PR

#### What are the relevant tickets?
#103 PR

#### Questions / Considerations

