### PR TITLE
Add babel-polyfill usage with sails-hook-babel config file + convert 500 arg in res.redirect() to string type

### DIFF
--- a/api/controllers/WebActionsController.js
+++ b/api/controllers/WebActionsController.js
@@ -199,7 +199,7 @@ module.exports = {
         if (mcSubscribeSuccessful) {
           return res.redirect(redirectUrl);
         } else {
-          return res.redirect(500);
+          return res.redirect('500');
         }
       });
   },
@@ -250,7 +250,7 @@ module.exports = {
       })
       .catch(err => {
         console.error(err);
-        res.redirect(500);
+        res.redirect('500');
       });
   },
 

--- a/config/babel.js
+++ b/config/babel.js
@@ -1,0 +1,11 @@
+/**
+ * Blueprint API Configuration
+ * (sails.config.babel)
+ *
+ * Custom config for SailsJS hook to activate ES6/7 Javascript code for your whole sails app
+ *
+ */
+
+module.exports.babel = {
+  polyfill: true
+};

--- a/config/babel.js
+++ b/config/babel.js
@@ -1,5 +1,5 @@
 /**
- * Blueprint API Configuration
+ * Sails-hook-babel configuration
  * (sails.config.babel)
  *
  * Custom config for SailsJS hook to activate ES6/7 Javascript code for your whole sails app


### PR DESCRIPTION
#### What's this PR do?
- Fixes `regeneratorRuntime is not defined` prod error by adding `babel-polyfill` via the sails-hook-babel config in `/config/babel.js.`  This should provide the necessary polyfill needed for babel to transform generator functions.
- Potentially fixes the `url.indexOf is not a function` error by passing 500 as a string type instead of number on response redirect.

#### How was this tested? How should this be reviewed?
- Tested the app locally by checking my referrals and seeing the regenerator error is no longer being thrown
- Was not able to reproduce the `url.indexOf` error but based on stack trace the 500 type change should fix the error

#### What are the relevant tickets?
#105 PR

#### Questions / Considerations
As discussed, will look further into how we can use presets without specifying them as a production dependency.
