### PR TITLE
Add rydel partner config and remove optional subhead element

### DIFF
--- a/api/services/partnersData.js
+++ b/api/services/partnersData.js
@@ -23,7 +23,7 @@ const partnersData = {
       imageUrl: 'https://media.giphy.com/media/YZZJNDPNPrq0w/giphy.gif',
       copy: 'You\'re all signed up!'
     },
-    campaignKey: 'OP24B7502371F978D24E98DD74A6D2281D'
+    campaignKey: process.env.RYDEL_MOBILECOMMONS_KEY
   }
 };
 

--- a/api/services/partnersData.js
+++ b/api/services/partnersData.js
@@ -14,7 +14,18 @@
  *    campaignKey: 'Mobile Commons partner opt-in path key'
  * }
  **/
-const partnersData = {};
+const partnersData = {
+  rydel: {
+    name: 'Sign up for confidence and positivity tips from Rydel!',
+    imageUrl: 'https://images.contentful.com/awpxl2koull4/VVLQ8XTSea46g2quYACMG/2d6b6d3b4787ed58367f10f09430998a/rydel_cropped.jpg',
+    copy: '',
+    confirmation: {
+      imageUrl: 'https://media.giphy.com/media/YZZJNDPNPrq0w/giphy.gif',
+      copy: 'You\'re all signed up!'
+    },
+    campaignKey: 'OP24B7502371F978D24E98DD74A6D2281D'
+  }
+};
 
 export default partnersData;
 

--- a/views/components/SignUpForm.js
+++ b/views/components/SignUpForm.js
@@ -3,12 +3,16 @@ import FormField from './FormField';
 
 const SignUpForm = props => {
   const { header, subhead, partnerId } = props;
+  let subHeadView;
+  if (subhead) {
+    subHeadView = <p>{subhead}</p>
+  }
   
   return (
       <div className="container-signup col-md-7">
       
         <h2>{header}</h2>
-        <p>{subhead}</p>
+        {subHeadView}
         
         <form class="signup-form" action="/join" method="post">
           <FormField isRequired label='First Name' type="text" fieldName='first_name' value=""/>


### PR DESCRIPTION
#### What's this PR do?
Adds partner configs for Rydel partner microsite launch

#### How was this tested? How should this be reviewed?
- Rydel image and header copy
- Check that signup works and opt-in path messages from Rydel's campaign are received
- Confirmation page has Rydel gif
