### PR TITLE
Hardcoding promoted.json url to pull blog content from

### DIFF
--- a/views/homepage.ejs
+++ b/views/homepage.ejs
@@ -82,7 +82,7 @@
       <li><p>You’ll receive a daily message Monday through Friday with quotes, research-backed articles, actions you can take, and more to help you start your morning off right.</p></li>
       <li><p><strong>93% of people</strong> who have used Shine texts say that they are more confident and have seen a noticeable improvement in their daily happiness.</p></li>
     </ol>
-    
+
     <div class="border"></div>
     <!-- Press -->
     <div class="in-the-news col-xs-12 col-xs-offset-0 col-md-12 col-md-offset-0">
@@ -108,7 +108,7 @@
           </a>
         </div>
       </div>
-      
+
       <div class="row col-md-offset-0">
         <div class="news-item col-xs-12 col-sm-6 col-md-6">
           <a href="https://www.popsugar.com/career/Interview-Founders-Shine-Text-43439065" target="_blank">
@@ -155,5 +155,5 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/skrollr/0.6.30/skrollr.min.js"></script>
 <!-- The promotedUrl var is used by homepage.js to fetch promoted articles -->
 <script>
-var promotedUrl = '<%= adviceBaseUrl %>/articles/promoted.json';
+var promotedUrl = 'https://s3.amazonaws.com/advice.shinetext.com/articles/promoted.json';
 </script>


### PR DESCRIPTION
This is meant to just be temporary until we can migrate this functionality to the updated torch repo

#### What's this PR do?
The blog is about to migrate over to the [torch](github.com/shinetext/torch) repo. It doesn't currently implement our updating of a `promoted.json` file. So this is just gonna hardcode to the old system which will still be running on S3 for the time being.

The intent is eventually to completely shutdown what we're doing on S3 and migrate all blog functionality over to *torch* and hosting it on Netlify.

#### How was this tested?
I just checked that the module was populated and working on my local setup. There isn't anything else related I'm neglecting is there?

