### PR TITLE
Updates handling of the promoted.json file

### DIFF
--- a/assets/js/homepage.js
+++ b/assets/js/homepage.js
@@ -1,8 +1,9 @@
 'use strict';
 
 $(document).ready(function() {
-
-  if (typeof promotedUrl === 'undefined') { return; }
+  if (typeof promotedUrl === 'undefined') {
+    return;
+  }
 
   // Helpers for managing the skrollr lib
   var skrollrInitialized = false;
@@ -16,7 +17,9 @@ $(document).ready(function() {
     data: null,
     dataType: 'json',
     success: function(data) {
-      if (! data || data.length === 0) { return; }
+      if (!data || data.length === 0) {
+        return;
+      }
 
       var MAX_PROMOTED_ARTICLES = 6;
       var articleData;
@@ -30,22 +33,27 @@ $(document).ready(function() {
         // Extract data and prep for rendering
         articleData = {
           article: {
-            category: data[i].category ? data[i].category['en-US'] : undefined,
-            photo: data[i].headerPhoto.file.url + '?w=640',
-            title: data[i].title['en-US'],
-            urlPath: data[i].urlPath,
+            category: data[i].category,
+            photo: data[i].headerPhoto.fields.file.url + '?w=640',
+            title: data[i].title,
+            slug: data[i].slug,
           },
           author: {
-            name: data[i].author.name,
-            photo: data[i].author.picture.file.url + '?fit=thumb&w=100&h=100',
+            name: data[i].author.fields.name,
+            photo: data[i].author.fields.picture.fields.file.url +
+              '?fit=thumb&w=100&h=100',
           },
         };
 
         // Render template with data
-        renderedHtml = ejs.render(template, articleData, {delimiter: '?'});
+        renderedHtml = ejs.render(template, articleData, { delimiter: '?' });
 
         // Add content to the page
-        $('#promoted-articles-results').append(renderedHtml).children(':last').hide().fadeIn(500);
+        $('#promoted-articles-results')
+          .append(renderedHtml)
+          .children(':last')
+          .hide()
+          .fadeIn(500);
       }
 
       // Now that articles are in place, can enable the parallax scrolling
@@ -57,7 +65,7 @@ $(document).ready(function() {
    * Initialize/refresh skrollr for when parallax elements get added to the DOM.
    */
   function refreshSkrollr() {
-    if (! skrollrInitialized) {
+    if (!skrollrInitialized) {
       skrollrInitialized = true;
 
       skrollrInstance = skrollr.init();
@@ -65,10 +73,8 @@ $(document).ready(function() {
         skrollrIsMobile = true;
         skrollrInstance.destroy();
       }
-    }
-    else if (! skrollrIsMobile) {
+    } else if (!skrollrIsMobile) {
       skrollrInstance.refresh();
     }
   }
-
 });

--- a/views/homepage.ejs
+++ b/views/homepage.ejs
@@ -155,5 +155,5 @@
 <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/skrollr/0.6.30/skrollr.min.js"></script>
 <!-- The promotedUrl var is used by homepage.js to fetch promoted articles -->
 <script>
-var promotedUrl = 'https://s3.amazonaws.com/advice.shinetext.com/articles/promoted.json';
+var promotedUrl = '<%= adviceBaseUrl %>/promoted.json';
 </script>

--- a/views/partials/promoted-articles.ejs
+++ b/views/partials/promoted-articles.ejs
@@ -16,7 +16,7 @@
     data-bottom-top="transform: translateY(5%); opacity: 0.9;"
     data-bottom-center="transform: translateY(0%);"
     data-bottom-bottom="opacity: 1;">
-    <a href="<%= adviceBaseUrl %>/<?= article.urlPath ?>">
+    <a href="<%= adviceBaseUrl %>/articles/<?= article.slug ?>">
       <div class="article-photo">
         <img src="<?= article.photo ?>">
       </div>


### PR DESCRIPTION
#### What's this PR do?
The new blog refresh now creates a promoted.json file for us to use here. So we're moving to using that one. The structure returned is slightly different than before, so there are changes here too to account for that.

#### How was this tested? How should this be reviewed?
The file path changes are in the .ejs files. The main structure updates in homepage.js are just happening in the setting of the `articleData` var. Everything else is from Prettier doing its thing.

Tested locally by pointing to a deploy preview version of the promoted.json file.

#### Considerations
Requires https://github.com/shinetext/torch/pull/72 to be deployed to production first.

**cc:** @kaladin9017 