### PR TITLE
Update homepage 'how shine works' copy

### DIFF
--- a/views/homepage.ejs
+++ b/views/homepage.ejs
@@ -78,7 +78,7 @@
       data-bottom-top="transform: translateY(30%); opacity: 0.8;"
       data--150-bottom-center="transform: translateY(0%);"
       data--150-bottom-bottom="opacity: 1;">
-      <li><p> Sign up for Shine and get your unique referral code to share with friends. (Psst: 10 friends starts to unlock <a href="http://www.shinetext.com/referrals" target="_blank">swag</a>.)</p></li>
+      <li><p>Sign up for Shine and get your unique referral code to share with friends. Referring 10 friends starts to unlock swag (hoodie: check, leggings: check check.).</p></li>
       <li><p>You’ll receive a daily message Monday through Friday with quotes, research-backed articles, actions you can take, and more to help you start your morning off right.</p></li>
       <li><p><strong>93% of people</strong> who have used Shine texts say that they are more confident and have seen a noticeable improvement in their daily happiness.</p></li>
     </ol>

--- a/views/homepage.ejs
+++ b/views/homepage.ejs
@@ -78,7 +78,7 @@
       data-bottom-top="transform: translateY(30%); opacity: 0.8;"
       data--150-bottom-center="transform: translateY(0%);"
       data--150-bottom-bottom="opacity: 1;">
-      <li><p>Sign up for Shine and get your unique referral code to share with friends. Referring 10 friends starts to unlock swag (hoodie: check, leggings: check check.).</p></li>
+      <li><p>Sign up for Shine and get your unique referral code to share with friends. Refer 10 friends to unlock <a href="http://www.shinetext.com/referrals" target="_blank">swag</a> (hoodie: check, leggings: check check.).</p></li>
       <li><p>You’ll receive a daily message Monday through Friday with quotes, research-backed articles, actions you can take, and more to help you start your morning off right.</p></li>
       <li><p><strong>93% of people</strong> who have used Shine texts say that they are more confident and have seen a noticeable improvement in their daily happiness.</p></li>
     </ol>

--- a/views/homepage.ejs
+++ b/views/homepage.ejs
@@ -78,7 +78,7 @@
       data-bottom-top="transform: translateY(30%); opacity: 0.8;"
       data--150-bottom-center="transform: translateY(0%);"
       data--150-bottom-bottom="opacity: 1;">
-      <li><p>Sign up for Shine and get your unique referral code to share with friends. Refer 10 friends to unlock <a href="http://www.shinetext.com/referrals" target="_blank">swag</a> (hoodie: check, leggings: check check.).</p></li>
+      <li><p>Sign up for Shine and get your unique referral code to share with friends. Refer 10 friends to unlock <a href="/referrals?utm_source=Shine&utm_medium=Home" target="_blank" ga-on="click">swag</a> (hoodie: check, leggings: check check.).</p></li>
       <li><p>You’ll receive a daily message Monday through Friday with quotes, research-backed articles, actions you can take, and more to help you start your morning off right.</p></li>
       <li><p><strong>93% of people</strong> who have used Shine texts say that they are more confident and have seen a noticeable improvement in their daily happiness.</p></li>
     </ol>

--- a/views/homepage.ejs
+++ b/views/homepage.ejs
@@ -78,7 +78,7 @@
       data-bottom-top="transform: translateY(30%); opacity: 0.8;"
       data--150-bottom-center="transform: translateY(0%);"
       data--150-bottom-bottom="opacity: 1;">
-      <li><p>Sign up for Shine and set a goal that you want to work on.</p></li>
+      <li><p> Sign up for Shine and get your unique referral code to share with friends. (Psst: 10 friends starts to unlock <a href="http://www.shinetext.com/referrals" target="_blank">swag</a>.)</p></li>
       <li><p>You’ll receive a daily message Monday through Friday with quotes, research-backed articles, actions you can take, and more to help you start your morning off right.</p></li>
       <li><p><strong>93% of people</strong> who have used Shine texts say that they are more confident and have seen a noticeable improvement in their daily happiness.</p></li>
     </ol>

--- a/views/privacy-policy.ejs
+++ b/views/privacy-policy.ejs
@@ -42,7 +42,7 @@
   <p>If we decide to change our privacy policy, we will post those changes on this page.</p>
 
   <h3>Got questions?</h3>
-  <p>Email us at <a href="mailto:contactus@shinetext.com" target="_top">contactus@shinetext.com</a></p>
+  <p>Email us at <a href="mailto:help@shinetext.com" target="_top">help@shinetext.com</a></p>
 
   <h3>Thank you!</h3>
 </div>


### PR DESCRIPTION
#### What's this PR do?
Updates 'How Shine Works' copy to remove goal-setting (temporarily turned off) and emphasize Shine referrals/swag.

#### How was this tested? How should this be reviewed?
- Checked copy was updated locally and the word 'swag' links to the referral page. 
- Verified that click event was captured in Google Analytics > Traffice Source with source and medium set from the utm parameters

#### What are the relevant tickets?
N/A

#### Questions / Considerations
In future, may want to consider having swag rewards info available upfront as another way to incentivize conversion (as noted in Slack channel)

@kaladin9017 @jonuy 
