### PR TITLE
React & ES6 on client-side

### DIFF
--- a/api/controllers/WebViewController.js
+++ b/api/controllers/WebViewController.js
@@ -203,7 +203,7 @@ module.exports = {
     try {
       const partner = PartnerService.getPartner(req.params.partner);
       const partnerComponentMarkup = ReactDOMServer.renderToString(
-        <PartnerApp {...partner} partnerId={req.params.partner} />
+        <PartnerApp />
       );
       const locals = {
         layout: 'layouts/subpage-fullwidth.layout',

--- a/assets/react-js/partner.js
+++ b/assets/react-js/partner.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import PartnerApp from '../../views/components/PartnerApp';
+
+console.log('rendering client side:')
+ReactDOM.render(<PartnerApp />, document.getElementById('react-app'));

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "description": "",
   "keywords": [],
   "dependencies": {
+    "babelify": "^7.3.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.5.2",
     "babel-preset-react": "^6.24.1",
@@ -13,6 +14,7 @@
     "dotenv": "^2.0.0",
     "ejs": "2.3.4",
     "grunt": "0.4.5",
+    "grunt-browserify": "^5.1.0",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-coffee": "0.13.0",
     "grunt-contrib-concat": "0.5.1",
@@ -43,8 +45,6 @@
   "main": "app.js",
   "devDependencies": {
     "babel-cli": "^6.24.1",
-    "babelify": "^7.3.0",
-    "grunt-browserify": "^5.1.0",
     "mocha": "^3.5.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
   "main": "app.js",
   "devDependencies": {
     "babel-cli": "^6.24.1",
+    "babelify": "^7.3.0",
+    "grunt-browserify": "^5.1.0",
     "mocha": "^3.5.0"
   }
 }

--- a/tasks/config/browserify.js
+++ b/tasks/config/browserify.js
@@ -1,0 +1,18 @@
+module.exports = function(grunt) {
+
+    grunt.config.set('browserify', {
+      dev: {
+        src: [
+            "./assets/react-js/partner.js",
+          ],
+          dest: '.tmp/public/react-js/partner.js',
+          options: {
+            browserifyOptions: { debug: true },
+            transform: [["babelify", { "presets": ["env", "react"] }]],
+          }
+        }
+    });
+
+    grunt.loadNpmTasks('grunt-browserify');
+
+};

--- a/tasks/config/copy.js
+++ b/tasks/config/copy.js
@@ -26,7 +26,7 @@ module.exports = function(grunt) {
       files: [{
         expand: true,
         cwd: './assets',
-        src: ['**/*.!(coffee|less|js)'],
+        src: ['**/*.!(coffee|less|partner.js)'],
         dest: '.tmp/public'
       }]
     },

--- a/tasks/config/copy.js
+++ b/tasks/config/copy.js
@@ -26,7 +26,7 @@ module.exports = function(grunt) {
       files: [{
         expand: true,
         cwd: './assets',
-        src: ['**/*.!(coffee|less)'],
+        src: ['**/*.!(coffee|less|js)'],
         dest: '.tmp/public'
       }]
     },

--- a/tasks/register/compileAssets.js
+++ b/tasks/register/compileAssets.js
@@ -17,6 +17,7 @@ module.exports = function(grunt) {
     'jst:dev',
     'less:dev',
     'copy:dev',
+    'browserify:dev',
     'coffee:dev'
   ]);
 };

--- a/views/components/FormField.js
+++ b/views/components/FormField.js
@@ -28,7 +28,7 @@ const FormField = props => {
           required={isRequired}
           value={value}
         />
-        <label for={fieldName}>{label}</label>
+        <label is for={fieldName}>{label}</label>
         {requiredField}
       </div>
     );

--- a/views/components/PartnerApp.js
+++ b/views/components/PartnerApp.js
@@ -1,8 +1,32 @@
 import React from 'react';
 import Image from './Image';
 import SignUpForm from './SignUpForm';
+import PartnerService from '../../api/services/PartnerService';
+
+//@TODO Remove hard-code partner string and get from window.location url param
+const partner = PartnerService.getPartner('rydel');
+
 
 class PartnerApp extends React.Component {
+    
+  constructor(props) {
+    super(props)
+    this.state = { isMounted: false, partner };
+
+    // This binding is necessary to make `this` work in the callback
+    this.handleClick = this.handleClick.bind(this);
+  }
+  componentDidMount() {
+    console.log('component did mount');
+    this.setState({
+      isMounted: true, partner
+    })
+  }
+  
+  handleClick() {
+    console.log('clicked');
+  }
+  
   render() {
     const {
       name,
@@ -12,23 +36,27 @@ class PartnerApp extends React.Component {
       campaignKeyBeta,
       additionalFields,
       additionalFormLink,
-    } = this.props;
+    } = this.state.partner;
+    console.log('partnr:', this.state.partner);
     const formDetails = {
       header: `${name}`,
       info: `${copy}`,
-      partnerId: partnerId,
+      partnerId: 'rydel',
       betaOptInPath: campaignKeyBeta,
       extras: additionalFields,
       additionalLink: additionalFormLink,
     };
-
+    
     return (
       <div className="container-partners-lead">
         <SignUpForm {...formDetails} />
         <Image src={imageUrl} />
+        <button onClick={this.handleClick}>Submit</button>
       </div>
+      
     );
   }
 }
 
 export default PartnerApp;
+

--- a/views/components/SignUpForm.js
+++ b/views/components/SignUpForm.js
@@ -2,6 +2,7 @@ import React from 'react';
 import AlphaSignUpForm from './AlphaSignUpForm';
 import BetaSignUpForm from './BetaSignUpForm';
 import FormField from './FormField';
+import PartnerService from '../../api/services/PartnerService';
 
 const SignUpForm = props => {
   const {
@@ -66,7 +67,7 @@ const SignUpForm = props => {
         <h2>{header}</h2>
         {infoView}
 
-        <form class="signup-form" action="/join" method="post">
+        <form is class="signup-form" action="/join" method="post">
           {alphaView}
           {betaView}
           {extrasView}

--- a/views/partner-signup.ejs
+++ b/views/partner-signup.ejs
@@ -1,3 +1,1 @@
-<div class="partner-page">
-    <%- partnerComponent %>
-</div>
+<div class="partner-page" id="react-app"><div><%- partnerComponent %></div><script src="/react-js/partner.js"></script></div>


### PR DESCRIPTION
#### What's this PR do?
Add grunt configurations to enable usage of react and es6 on the frontend so that function handlers and other DOM stuff can be done

`npm install` to add new dev dependencies - `grunt-browserify` & `babelify`



#### How was this tested? How should this be reviewed?
Added a test submit button on the PartnerApp component to test whether handleClick event is triggered.
`npm run start`
Hardcoded 'rydel' as the partnerId at the moment - 
`go to http://localhost:1337/p/rydel`

#### Questions / Considerations
Don't think there's any changes needed on the production build with the current set up (like modifying `sails-linker.js`) but something to keep in mind

@kaladin9017 @jonuy 