### PR TITLE
Possible fix to 'first seen' referral tracking on Mobile Commons

### DIFF
--- a/api/controllers/WebActionsController.js
+++ b/api/controllers/WebActionsController.js
@@ -54,7 +54,7 @@ module.exports = {
       let friendCounter = 0;
       for (const friend of req.body.friends) {
         if (typeof friend === 'object' && friend.phone) {
-          data.form[`friends[${friendCounter}]`] = friend.phone;
+          data.form[`friends[${friendCounter}][phone]`] = friend.phone;
           friendCounter++;
         }
       }


### PR DESCRIPTION
#### What's this PR do?
Reverts the way friends are added to a signup web form back to previous version.

The problem is that the "first seen" property seems to have changed in such a way that our system that would allow us to track these referrals will no longer work.

Every profile in Mobile Commons has a "first seen" property. In certain cases, like this, it's used to determine if a user was invited to Shine by someone else. When that's the case, it'll show up as: `First seen: Forwarded from 1-xxx-xxx-xxxx`. We're then able to use that number to make the referral connection.

But since the change, that value instead has turned to `First seen: Add via API`. And this doesn't give us the info we need to make the connection.

#### How was this tested?
Tested the scholarship signup form. Will test both that and the homepage signup form before merging to prod.