### PR TITLE
fix case sensitive partner routes

### DIFF
--- a/api/controllers/WebViewController.js
+++ b/api/controllers/WebViewController.js
@@ -214,9 +214,10 @@ module.exports = {
    */
   partners: function(req, res) {
     try {
-      const partner = PartnerService.getPartner(req.params.partner);
+      const partnerName = req.params.partner.toLowerCase();
+      const partner = PartnerService.getPartner(partnerName);
       const partnerComponentMarkup = ReactDOMServer.renderToString(
-        <PartnerApp {...partner} partnerId={req.params.partner} />
+        <PartnerApp {...partner} partnerId={partnerName} />
       );
       const locals = {
         layout: 'layouts/subpage-fullwidth.layout',


### PR DESCRIPTION
#### What's this PR do?
Adds ``` toLowerCase ``` function to partner routes in ``` WebViewController.js ```. This should fix any mixing of cases in partner routes. If a user navigates to ``` Self-Care-scholarship-2017 ``` the ``` PartnerServices.js `` function should now be able to lookup all the information needed for the ``` self-care-scholarship-2017 ``` route. 

#### How was this tested? How should this be reviewed?
Tested locally on chrome and safari for views.  

#### What are the relevant tickets?
N/A just an error/bug that came up. 

#### Questions / Considerations
This shouldn't have affected a majority of users because the only visibility for the link is on fastweb but for future partners with simple URL ```/p/Rydel ``` when people share this could become a problem.

All future partner/campaign JSON keys should always be lowercase. 

@cl2205