### PR TITLE
Adds method for attempting to safely update a Mobile Commons profile

### DIFF
--- a/api/controllers/WebActionsController.js
+++ b/api/controllers/WebActionsController.js
@@ -112,8 +112,6 @@ module.exports = {
     // @param context {object}
     //
     function safeMCProfileUpdate(context) {
-      console.log('PARAMS:', context);
-
       Promise.coroutine(function*() {
         // Check Mobile Commons if the profile exists
         const profileResponse = yield queryProfileAPI(context.friend.phone);
@@ -144,39 +142,39 @@ module.exports = {
 
           request.postAsync(updateRequest);
         }
-
-        //
-        // Queries the Mobile Commons profile API for a specific phone number.
-        //
-        // @param {string} phone
-        // @return Promise
-        //
-        function queryProfileAPI(phone) {
-          return new Promise((resolve, reject) => {
-            const url = `https://secure.mcommons.com/api/profiles?phone_number=${phone}`;
-            const options = {
-              auth: {
-                user: sails.config.globals.mobileCommonsUser,
-                pass: sails.config.globals.mobileCommonsPassword,
-              },
-            };
-
-            request.get(url, options, function(err, response, body) {
-              if (err) {
-                reject(err);
-              } else if (response && response.statusCode !== 200) {
-                reject(
-                  new Error(
-                    `Error querying Mobile Commons profile API: ${response.statusCode}`
-                  )
-                );
-              } else {
-                resolve(body);
-              }
-            });
-          });
-        }
       })();
+    }
+
+    //
+    // Queries the Mobile Commons profile API for a specific phone number.
+    //
+    // @param {string} phone
+    // @return Promise
+    //
+    function queryProfileAPI(phone) {
+      return new Promise((resolve, reject) => {
+        const url = `https://secure.mcommons.com/api/profiles?phone_number=${phone}`;
+        const options = {
+          auth: {
+            user: sails.config.globals.mobileCommonsUser,
+            pass: sails.config.globals.mobileCommonsPassword,
+          },
+        };
+
+        request.get(url, options, function(err, response, body) {
+          if (err) {
+            reject(err);
+          } else if (response && response.statusCode !== 200) {
+            reject(
+              new Error(
+                `Error querying Mobile Commons profile API: ${response.statusCode}`
+              )
+            );
+          } else {
+            resolve(body);
+          }
+        });
+      });
     }
   },
 

--- a/api/controllers/WebActionsController.js
+++ b/api/controllers/WebActionsController.js
@@ -95,7 +95,7 @@ module.exports = {
     // Maximum number of times retry a profile check
     const MAX_MC_PROFILE_CHECK_RETRIES = 5;
     // Time delay between retries
-    const MC_PROFILE_CHECK_RETRY_DELAY = 2500;
+    const MC_PROFILE_CHECK_RETRY_DELAY = 5000;
 
     for (const friend of friends) {
       if (typeof friend === 'object' && friend.first_name && friend.phone) {

--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
   "description": "",
   "keywords": [],
   "dependencies": {
+    "@jonuy/referral-codes": "1.1.0",
     "babel-plugin-transform-builtin-extend": "^1.1.2",
     "babel-preset-env": "^1.5.2",
     "babel-preset-react": "^6.24.1",
-    "@jonuy/referral-codes": "1.1.0",
     "bluebird": "^3.4.1",
     "dotenv": "^2.0.0",
     "ejs": "2.3.4",
@@ -33,7 +33,8 @@
     "request": "^2.72.0",
     "sails": "~0.12.3",
     "sails-disk": "~0.10.9",
-    "sails-hook-babel": "^6.0.3"
+    "sails-hook-babel": "^6.0.3",
+    "xml2js": "^0.4.19"
   },
   "scripts": {
     "debug": "node debug app.js",


### PR DESCRIPTION
#### What's this PR do?
Another attempt at solving the beta referral and profile updating issues. This PR removes the temporary solution (which never made it to prod) of creating the beta users on our own Photon database. And it replaces it with a multi-step process where we intermittently check Mobile Commons to see if the profile exists and then updating the profile data if it does. If it's not found, then it'll retry up to 5 times before making the update anyway.

#### Some specifics
- `safeMCProfileUpdate`: The function for doing all the main logic mentioned above. For retries, it calls itself through a `setTimeout`.
- `queryProfileAPI`: A helper function for doing the GET request on the /profiles API endpoint. The response is in XML, which is why there's the need for the `xml2js.parseStringAsync` line.

#### Questions / Considerations
- Should we maybe not update the profile if we've found it hasn't been created yet? I'm leaning towards still doing the update so that we're not just dropping data.
- It's unknown right now how long it takes Mobile Commons to create the beta/friend profiles. We're working off the assumption/hope that it'll happen at least within 25 seconds of the /join submission. I'll be reaching out to their support to see if they've got an idea of the max time it should take.

cc: @kaladin9017 