### PR TITLE
add control over number of beta signup forms

### DIFF
--- a/api/controllers/WebActionsController.js
+++ b/api/controllers/WebActionsController.js
@@ -87,7 +87,7 @@ module.exports = {
   /**
    * Helper method for updating friend profiles after they've been invited
    * from an Alpha's join request.
-   * 
+   *
    * @param {string} phone Phone number of the inviter
    * @param {array} friends Data on the invitees
    */

--- a/api/services/partnersData.js
+++ b/api/services/partnersData.js
@@ -46,6 +46,7 @@ const partnersData = {
       label: 'Official Scholarship Rules',
       link: '/files/scholarship-rules-2017.pdf',
     },
+    referralCount: 1,
   },
 };
 

--- a/api/services/partnersData.js
+++ b/api/services/partnersData.js
@@ -31,7 +31,7 @@ const partnersData = {
   'self-care-scholarship-2017': {
     name: '$1,000 Easy Self-Care Scholarship - Fall 2017',
     imageUrl: '/images/partners/scholarship/scholarship-2017-photo.jpg',
-    copy: '<p>School can be stressful.</p><p>Sign up to get a free daily text message to help you practice self-care AND get a chance to earn cash for school.</p><p>To enter the $1,000 scholarship, sign up for <a href="/?utm_source=Shine&utm_medium=Scholarship">Shine</a> texts below & share with 3 friends.</p>',
+    copy: '<p>School can be stressful.</p><p>Sign up to get a free daily text message to help you practice self-care AND get a chance to earn cash for school.</p><p>To enter the $1,000 scholarship, sign up for <a href="/?utm_source=Shine&utm_medium=Scholarship">Shine</a> texts below & share with a friend.</p>',
     confirmation: {
       imageUrl: '/images/partners/scholarship/confirmation.gif',
       copy: 'You’ve entered the Shine Self-Care Scholarship!',
@@ -49,7 +49,7 @@ const partnersData = {
       label: 'Official Scholarship Rules',
       link: '/files/scholarship-rules-2017.pdf',
     },
-    betaCount: 3,
+    betaCount: 1,
   },
 };
 

--- a/api/services/partnersData.js
+++ b/api/services/partnersData.js
@@ -13,7 +13,7 @@
  *    },
  *    campaignKey: 'Mobile Commons partner opt-in path key'
  *    campaignKeyBeta: 'Optional key for signing up beta users',
- *     referralCount: Number controling the amount of referral inputs to display,
+ *     betaCount: Number controling the amount of referral input fields to display,
  *    },
  * }
  */
@@ -49,7 +49,7 @@ const partnersData = {
       label: 'Official Scholarship Rules',
       link: '/files/scholarship-rules-2017.pdf',
     },
-    referralCount: 1,
+    betaCount: 3,
   },
 };
 

--- a/api/services/partnersData.js
+++ b/api/services/partnersData.js
@@ -12,6 +12,9 @@
  *      copy: 'confirmation copy'
  *    },
  *    campaignKey: 'Mobile Commons partner opt-in path key'
+ *    campaignKeyBeta: 'Optional key for signing up beta users',
+ *     referralCount: Number controling the amount of referral inputs to display,
+ *    },
  * }
  */
 const partnersData = {

--- a/views/components/BetaSignUpForm.js
+++ b/views/components/BetaSignUpForm.js
@@ -1,63 +1,62 @@
 import React from 'react';
 import FormField from './FormField';
 
-const BetaSignUpForm = props => {
+const BetaSignUpForm = ({ optin, betaCount }) => {
+  let fieldViews = [];
+  let defaultBetaCount = 3;
+  // If a specific number of referral/beta fields are given. Check if betaCount is
+  // 1 and singularize the header. Also loop over beta count and add FormFields.
+  let PluralOrSingularFriends = betaCount == 1 ? 'Friend' : 'Friends';
+  if (betaCount) {
+    for (let i = 0; i < betaCount; i++) {
+      fieldViews.push(
+        <div className="friend-fields-container" key={i}>
+          <FormField
+            isRequired
+            label={`Friend ${i + 1}'s First Name`}
+            type="text"
+            fieldName={`friends[${i}][first_name]`}
+            value=""
+          />
+          <FormField
+            isRequired
+            label={`Friend ${i + 1}'s Cell Number`}
+            type="tel"
+            fieldName={`friends[${i}][phone]`}
+            value=""
+          />
+        </div>
+      );
+    }
+  } else {
+    // If no specific number of referral/beta fields use the default number of fields.
+    for (let i = 0; i < defaultBetaCount; i++) {
+      fieldViews.push(
+        <div className="friend-fields-container" key={i}>
+          <FormField
+            isRequired
+            label={`Friend ${i + 1}'s First Name`}
+            type="text"
+            fieldName={`friends[${i}][first_name]`}
+            value=""
+          />
+          <FormField
+            isRequired
+            label={`Friend ${i + 1}'s Cell Number`}
+            type="tel"
+            fieldName={`friends[${i}][phone]`}
+            value=""
+          />
+        </div>
+      );
+    }
+  }
   return (
     <div className="BetaSignUpForm">
-      <h4>Share Shine with 3 Friends:</h4>
-      <div className="friend-fields-container">
-        <FormField
-          isRequired
-          label="Friend 1's First Name"
-          type="text"
-          fieldName="friends[0][first_name]"
-          value=""
-        />
-        <FormField
-          isRequired
-          label="Friend 1's Cell Number"
-          type="tel"
-          fieldName="friends[0][phone]"
-          value=""
-        />
-      </div>
-      <div className="friend-fields-container">
-        <FormField
-          isRequired
-          label="Friend 2's First Name"
-          type="text"
-          fieldName="friends[1][first_name]"
-          value=""
-        />
-        <FormField
-          isRequired
-          label="Friend 2's Cell Number"
-          type="tel"
-          fieldName="friends[1][phone]"
-          value=""
-        />
-      </div>
-      <div className="friend-fields-container">
-        <FormField
-          isRequired
-          label="Friend 3's First Name"
-          type="text"
-          fieldName="friends[2][first_name]"
-          value=""
-        />
-        <FormField
-          isRequired
-          label="Friend 3's Cell Number"
-          type="tel"
-          fieldName="friends[2][phone]"
-          value=""
-        />
-      </div>
-      <FormField
-        type="hidden"
-        fieldName="friends_opt_in_path"
-        value={props.optin}
-      />
+      <h4>
+        Share Shine with {betaCount || defaultBetaCount} {PluralOrSingularFriends}:
+      </h4>
+      {fieldViews}
     </div>
   );
 };

--- a/views/components/BetaSignUpForm.js
+++ b/views/components/BetaSignUpForm.js
@@ -2,13 +2,13 @@ import React from 'react';
 import FormField from './FormField';
 
 const BetaSignUpForm = ({ optin, betaCount }) => {
-  let fieldViews = [];
-  let defaultBetaCount = 3;
+  const fieldViews = [];
+  const defaultBetaCount = 3;
   // If a specific number of referral/beta fields are given. Check if betaCount is
   // 1 and singularize the header. Also loop over beta count and add FormFields.
-  let PluralOrSingularFriends = betaCount == 1 ? 'Friend' : 'Friends';
-  if (betaCount) {
-    for (let i = 0; i < betaCount; i++) {
+  let pluralOrSingularFriends = betaCount == 1 ? 'Friend' : 'Friends';
+  let numBetas = betaCount || defaultBetaCount;
+    for (let i = 0; i < numBetas; i++) {
       fieldViews.push(
         <div className="friend-fields-container" key={i}>
           <FormField
@@ -28,33 +28,10 @@ const BetaSignUpForm = ({ optin, betaCount }) => {
         </div>
       );
     }
-  } else {
-    // If no specific number of referral/beta fields use the default number of fields.
-    for (let i = 0; i < defaultBetaCount; i++) {
-      fieldViews.push(
-        <div className="friend-fields-container" key={i}>
-          <FormField
-            isRequired
-            label={`Friend ${i + 1}'s First Name`}
-            type="text"
-            fieldName={`friends[${i}][first_name]`}
-            value=""
-          />
-          <FormField
-            isRequired
-            label={`Friend ${i + 1}'s Cell Number`}
-            type="tel"
-            fieldName={`friends[${i}][phone]`}
-            value=""
-          />
-        </div>
-      );
-    }
-  }
   return (
     <div className="BetaSignUpForm">
       <h4>
-        Share Shine with {betaCount || defaultBetaCount} {PluralOrSingularFriends}:
+        Share Shine with {numBetas} {pluralOrSingularFriends}:
       </h4>
       {fieldViews}
     </div>

--- a/views/components/PartnerApp.js
+++ b/views/components/PartnerApp.js
@@ -12,6 +12,7 @@ class PartnerApp extends React.Component {
       campaignKeyBeta,
       additionalFields,
       additionalFormLink,
+      referralCount,
     } = this.props;
     const formDetails = {
       header: `${name}`,
@@ -20,6 +21,7 @@ class PartnerApp extends React.Component {
       betaOptInPath: campaignKeyBeta,
       extras: additionalFields,
       additionalLink: additionalFormLink,
+      betaCount: referralCount,
     };
 
     return (

--- a/views/components/PartnerApp.js
+++ b/views/components/PartnerApp.js
@@ -12,7 +12,7 @@ class PartnerApp extends React.Component {
       campaignKeyBeta,
       additionalFields,
       additionalFormLink,
-      referralCount,
+      betaCount,
     } = this.props;
     const formDetails = {
       header: `${name}`,
@@ -21,7 +21,7 @@ class PartnerApp extends React.Component {
       betaOptInPath: campaignKeyBeta,
       extras: additionalFields,
       additionalLink: additionalFormLink,
-      betaCount: referralCount,
+      betaCount: betaCount,
     };
 
     return (

--- a/views/components/SignUpForm.js
+++ b/views/components/SignUpForm.js
@@ -13,6 +13,7 @@ const SignUpForm = props => {
     betaOptInPath,
     extras,
     additionalLink,
+    betaCount
   } = props;
 
   let infoView;
@@ -31,7 +32,7 @@ const SignUpForm = props => {
 
   let betaView;
   if (betaOptInPath) {
-    betaView = <BetaSignUpForm optin={betaOptInPath} />;
+    betaView = <BetaSignUpForm betaCount={betaCount} optin={betaOptInPath} />;
   }
 
   let extrasView = [];


### PR DESCRIPTION
#### What's this PR do?
Adds logic to control the number of input fields that the ``` BetaSignUpForm.js ``` displays. 

#### How was this tested? How should this be reviewed?
Tested locally on campaign and partner routes.

#### What are the relevant tickets?
N/A

#### Questions / Considerations
I checked on my local environment and found no conflicts with the number of friends referrals being different than the static 3 fields that it was before but I might have missed something. 

@cl2205 