### PR TITLE
Reverts back to upserting beta users to photon to set referred_by value

### DIFF
--- a/api/controllers/WebActionsController.js
+++ b/api/controllers/WebActionsController.js
@@ -6,7 +6,6 @@
 
 const Promise = require('bluebird');
 const request = Promise.promisifyAll(require('request'));
-const xml2js = Promise.promisifyAll(require('xml2js'));
 const Mixpanel = require('mixpanel');
 let mixpanel;
 
@@ -92,89 +91,39 @@ module.exports = {
    * @param {array} friends Data on the invitees
    */
   updateFriendProfiles: function(phone, friends) {
-    // Maximum number of times retry a profile check
-    const MAX_MC_PROFILE_CHECK_RETRIES = 5;
-    // Time delay between retries
-    const MC_PROFILE_CHECK_RETRY_DELAY = 5000;
-
     for (const friend of friends) {
       if (typeof friend === 'object' && friend.first_name && friend.phone) {
-        safeMCProfileUpdate({
-          friend: friend,
-          retriesRemaining: MAX_MC_PROFILE_CHECK_RETRIES,
-        });
-      }
-    }
-
-    //
-    // Checks for the existence of a user on Mobile Commons before
-    //
-    // @param context {object}
-    //
-    function safeMCProfileUpdate(context) {
-      Promise.coroutine(function*() {
-        // Check Mobile Commons if the profile exists
-        const profileResponse = yield queryProfileAPI(context.friend.phone);
-        const profile = yield xml2js.parseStringAsync(profileResponse);
-        const foundProfile = profile.response.$.success === 'true';
-
-        if (!foundProfile && context.retriesRemaining > 0) {
-          // If it doesn't exist, then try again after a short delay
-          context.retriesRemaining--;
-          setTimeout(
-            safeMCProfileUpdate.bind(undefined, context),
-            MC_PROFILE_CHECK_RETRY_DELAY
-          );
-        } else {
-          // But if it is there, then we can safely update the profile
-          const updateRequest = {
-            url: `https://secure.mcommons.com/api/profile_update`,
-            auth: {
-              user: sails.config.globals.mobileCommonsUser,
-              pass: sails.config.globals.mobileCommonsPassword,
-            },
-            form: {
-              phone_number: context.friend.phone,
-              first_name: context.friend.first_name,
-              referral_code: ReferralCodes.encode(context.friend.phone),
-            },
-          };
-
-          request.postAsync(updateRequest);
-        }
-      })();
-    }
-
-    //
-    // Queries the Mobile Commons profile API for a specific phone number.
-    //
-    // @param {string} phone
-    // @return Promise
-    //
-    function queryProfileAPI(phone) {
-      return new Promise((resolve, reject) => {
-        const url = `https://secure.mcommons.com/api/profiles?phone_number=${phone}`;
-        const options = {
+        // Update the user profiles on Mobile Commons
+        const mobilecommonsRequest = {
+          url: `https://secure.mcommons.com/api/profile_update`,
           auth: {
             user: sails.config.globals.mobileCommonsUser,
             pass: sails.config.globals.mobileCommonsPassword,
           },
+          form: {
+            phone_number: friend.phone,
+            first_name: friend.first_name,
+            referral_code: ReferralCodes.encode(friend.phone),
+          },
         };
 
-        request.get(url, options, function(err, response, body) {
-          if (err) {
-            reject(err);
-          } else if (response && response.statusCode !== 200) {
-            reject(
-              new Error(
-                `Error querying Mobile Commons profile API: ${response.statusCode}`
-              )
-            );
-          } else {
-            resolve(body);
-          }
-        });
-      });
+        request.postAsync(mobilecommonsRequest);
+
+        // Upsert the user profiles on our own Photon backed
+        // Particularly necessary for tracking the referred_by value properly.
+        let photonRequest = {
+          method: 'POST',
+          uri: sails.config.globals.photonApiUrl + '/signup',
+          json: true,
+          body: {
+            firstName: friend.first_name,
+            phone: friend.phone,
+            referredByCode: ReferralCodes.encode(phone),
+          },
+        };
+
+        request.postAsync(photonRequest);
+      }
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "request": "^2.72.0",
     "sails": "~0.12.3",
     "sails-disk": "~0.10.9",
-    "sails-hook-babel": "^6.0.3",
-    "xml2js": "^0.4.19"
+    "sails-hook-babel": "^6.0.3"
   },
   "scripts": {
     "debug": "node debug app.js",


### PR DESCRIPTION
#### What's this PR do?
By setting these users in photon here, we can set their referred_by value and accurately track referrals.

No longer doing the retries. The accounts on Mobile Commons would only be ready once the beta/friend user accepts the invite. And when invites are accepted, it could take anywhere from minutes to hours to days. And I don't think we'll want a system that indefinitely polls Mobile Commons for forever.

#### More context
Planning on also pushing this up in conjunction with [this change](https://github.com/shinetext/photon/pull/7) on the photon API. The changes being made there should account for at least the problems we'd thought about before. ie - referrals getting credited to the wrong people