### PR TITLE
update partner&campaign header and remove optional field from scholarships

### DIFF
--- a/api/services/partnersData.js
+++ b/api/services/partnersData.js
@@ -38,13 +38,6 @@ const partnersData = {
     },
     campaignKey: 'OPF103C6C3AE571FD2082D4B7F18929F5B',
     campaignKeyBeta: 'OP3969113B4E740F300A09B3D2D1D05CB8',
-    additionalFields: [
-      {
-        type: 'textarea',
-        name: 'scholarship_why_important',
-        label: 'Why is self-care important to you? (optional)',
-      },
-    ],
     additionalFormLink: {
       label: 'Official Scholarship Rules',
       link: '/files/scholarship-rules-2017.pdf',

--- a/views/components/BetaSignUpForm.js
+++ b/views/components/BetaSignUpForm.js
@@ -3,36 +3,47 @@ import FormField from './FormField';
 
 const BetaSignUpForm = ({ optin, betaCount }) => {
   const fieldViews = [];
+  let headerViews;
   const defaultBetaCount = 3;
   // If a specific number of referral/beta fields are given. Check if betaCount is
-  // 1 and singularize the header. Also loop over beta count and add FormFields.
-  let pluralOrSingularFriends = betaCount == 1 ? 'Friend' : 'Friends';
+  // 1 and singularize the header. Loop over beta count and add FormFields.
   let numBetas = betaCount || defaultBetaCount;
-    for (let i = 0; i < numBetas; i++) {
-      fieldViews.push(
-        <div className="friend-fields-container" key={i}>
-          <FormField
-            isRequired
-            label={`Friend ${i + 1}'s First Name`}
-            type="text"
-            fieldName={`friends[${i}][first_name]`}
-            value=""
-          />
-          <FormField
-            isRequired
-            label={`Friend ${i + 1}'s Cell Number`}
-            type="tel"
-            fieldName={`friends[${i}][phone]`}
-            value=""
-          />
-        </div>
-      );
-    }
+  if (numBetas <= 1) {
+    headerViews = <h4>Share Shine with a Friend:</h4>;
+  } else {
+    headerViews = (
+      <h4>
+        Share Shine with {numBetas} Friends:
+      </h4>
+    );
+  }
+  for (let i = 0; i < numBetas; i++) {
+    let nameLabel =
+      numBetas > 1 ? `Friend ${i + 1}'s First Name` : "Your Friend's Name";
+    let phoneLabel =
+      numBetas > 1 ? `Friend ${i + 1}'s Cell Number` : "Your Friend's Number";
+    fieldViews.push(
+      <div className="friend-fields-container" key={i}>
+        <FormField
+          isRequired
+          label={nameLabel}
+          type="text"
+          fieldName={`friends[${i}][first_name]`}
+          value=""
+        />
+        <FormField
+          isRequired
+          label={phoneLabel}
+          type="tel"
+          fieldName={`friends[${i}][phone]`}
+          value=""
+        />
+      </div>
+    );
+  }
   return (
     <div className="BetaSignUpForm">
-      <h4>
-        Share Shine with {numBetas} {pluralOrSingularFriends}:
-      </h4>
+      {headerViews}
       {fieldViews}
     </div>
   );


### PR DESCRIPTION

#### What's this PR do?
1. Updates header components on ``` BetaSignUpForm ``` page. If the number of referral fields is < 1 change the form header else list the number of friends required to submit the form.

2. Remove additional comment box on ``` /p/self-care-scholarship-2017 ``` page. 

#### How was this tested? How should this be reviewed?
Tested locally and will test again on heroku-deploy-preview.

#### What are the relevant tickets?
N/A Updated with input from @marahml , Naomi and Colleen.

#### Questions / Considerations
I am seriously considering pulling ``` headerViews ``` into a seperate component.