### PR TITLE
remove beta referrals from partner/scholarship

### DIFF
--- a/api/services/partnersData.js
+++ b/api/services/partnersData.js
@@ -37,12 +37,10 @@ const partnersData = {
       copy: 'You’ve entered the Shine Self-Care Scholarship!',
     },
     campaignKey: 'OPF103C6C3AE571FD2082D4B7F18929F5B',
-    campaignKeyBeta: 'OP3969113B4E740F300A09B3D2D1D05CB8',
     additionalFormLink: {
       label: 'Official Scholarship Rules',
       link: '/files/scholarship-rules-2017.pdf',
     },
-    betaCount: 1,
   },
 };
 


### PR DESCRIPTION
#### What's this PR do?
Remove beta referrals from scholarship partner routes.

#### How was this tested? How should this be reviewed?
Tested using chrome.  Beta referrals are added if the partner has a beta opt-in path.

#### What are the relevant tickets?
N/A. Raised in product checkin.

#### Questions / Considerations
All future scholarships should be moved to campaign route and possibly make recommending friends optional but provide an extra entry into a scholarship?
