### PR TITLE
Removes Shine Talk routes

### DIFF
--- a/api/controllers/WebViewController.js
+++ b/api/controllers/WebViewController.js
@@ -44,13 +44,6 @@ module.exports = {
     return res.redirect(301, sails.config.globals.dailyShineBaseUrl);
   },
 
-  /**
-   * Redirect to the Shinevisor page.
-   */
-  talk: (req, res) => {
-    return res.redirect(301, sails.config.globals.talkBaseUrl);
-  },
-
   ////////////////////////////////////////////////////////////////////////////
 
   squad: (req, res) => {

--- a/assets/sitemap.txt
+++ b/assets/sitemap.txt
@@ -1,6 +1,5 @@
 http://www.shinetext.com/advice
 http://www.shinetext.com/daily
-http://www.shinetext.com/talk
 http://www.shinetext.com/referrals
 http://www.shinetext.com/squad
 http://www.shinetext.com/faq

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -11,7 +11,6 @@
  */
 
 module.exports = {
-
   /***************************************************************************
    * Set the default database connection for models in the development       *
    * environment (see config/connections.js and config/models.js )           *
@@ -38,14 +37,10 @@ module.exports = {
     // The Photon API URL
     photonApiUrl: process.env.PHOTON_API_URL || 'http://localhost:1338',
 
-    // Base URL for the talk / Shinevisor platform
-    talkBaseUrl: process.env.TALK_BASE_URL,
-
     // MailChimp
     mailchimpApiAuthUser: process.env.MAILCHIMP_API_USER,
     mailchimpApiAuthPass: process.env.MAILCHIMP_API_PASSWORD,
     mailchimpApiUrl: process.env.MAILCHIMP_API_URL,
     mailchimpListId: process.env.MAILCHIMP_LIST_ID,
   },
-
 };

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -11,7 +11,6 @@
  */
 
 module.exports = {
-
   /***************************************************************************
    * Set the default database connection for models in the production        *
    * environment (see config/connections.js and config/models.js )           *
@@ -52,14 +51,10 @@ module.exports = {
     // The Photon API URL
     photonApiUrl: process.env.PHOTON_API_URL,
 
-    // Base URL for the talk / Shinevisor platform
-    talkBaseUrl: process.env.TALK_BASE_URL,
-
     // MailChimp
     mailchimpApiAuthUser: process.env.MAILCHIMP_API_USER,
     mailchimpApiAuthPass: process.env.MAILCHIMP_API_PASSWORD,
     mailchimpApiUrl: process.env.MAILCHIMP_API_URL,
     mailchimpListId: process.env.MAILCHIMP_LIST_ID,
   },
-
 };

--- a/config/routes.js
+++ b/config/routes.js
@@ -92,9 +92,6 @@ var routes = {
 
   '/squad': 'WebViewController.squad',
 
-  '/shinevisor*': 'WebViewController.talk',
-  '/talk*': 'WebViewController.talk',
-
   '/terms-of-service': {
     view: 'terms-of-service',
     locals: {

--- a/test/integration/controllers/WebActionsController.test.js
+++ b/test/integration/controllers/WebActionsController.test.js
@@ -4,7 +4,7 @@ const WebActionsController = require('../../../api/controllers/WebActionsControl
 describe('WebActionsController', () => {
   describe('#createMobileCommonsRequest', () => {
     it('should return the POST object for a Mobile Commons sign up', () => {
-      const mockRequest = {
+      const req = {
         body: {
           first_name: 'TEST_FNAME',
           phone: '+1 (301) 555-0101',
@@ -12,13 +12,16 @@ describe('WebActionsController', () => {
         },
       };
 
-      const data = WebActionsController.createMobileCommonsRequest(mockRequest);
+      const data = WebActionsController.createMobileCommonsRequest(req);
       assert.equal(typeof data, 'object');
       assert.equal(typeof data.form, 'object');
-      assert.equal(data.form['opt_in_path[]'], WebActionsController.MOBILE_COMMONS_OPTIN);
-      assert.equal(data.form['person[first_name]'], mockRequest.body.first_name);
-      assert.equal(data.form['person[phone]'], mockRequest.body.phone);
-      assert.equal(data.form['person[email]'], mockRequest.body.email);
+      assert.equal(
+        data.form['opt_in_path[]'],
+        WebActionsController.MOBILE_COMMONS_OPTIN
+      );
+      assert.equal(data.form['person[first_name]'], req.body.first_name);
+      assert.equal(data.form['person[phone]'], req.body.phone);
+      assert.equal(data.form['person[email]'], req.body.email);
       assert.equal(data.form['person[send_gifs]'], 'no');
       assert.equal(data.form['person[referral_code]'], 'qGl0G4r');
 
@@ -34,7 +37,7 @@ describe('WebActionsController', () => {
     });
 
     it('should add extras as custom fields to the user signing up', () => {
-      const mockRequest = {
+      const req = {
         body: {
           first_name: 'TEST_FNAME',
           phone: '3015550100',
@@ -45,44 +48,41 @@ describe('WebActionsController', () => {
         },
       };
 
-      const data = WebActionsController.createMobileCommonsRequest(mockRequest);
-      assert.equal(data.form['person[key1]'], mockRequest.body.extras.key1);
-      assert.equal(data.form['person[key2]'], mockRequest.body.extras.key2);
+      const data = WebActionsController.createMobileCommonsRequest(req);
+      assert.equal(data.form['person[key1]'], req.body.extras.key1);
+      assert.equal(data.form['person[key2]'], req.body.extras.key2);
     });
 
     it('should handle a sign up with friends', () => {
-      const mockRequest = {
+      const req = {
         body: {
           first_name: 'TEST_FNAME',
           phone: '3015550100',
           opt_in_path: 'ALPHA_OIP',
           friends_opt_in_path: 'BETA_OIP',
           friends: [
-            { first_name: 'BETA1', phone: '3015550101' },
-            { first_name: 'BETA2', phone: '3015550102' },
-            { first_name: 'BETA3', phone: '3015550103' },
+            { phone: '3015550101' },
+            { phone: '3015550102' },
+            { phone: '3015550103' },
           ],
         },
       };
 
-      const data = WebActionsController.createMobileCommonsRequest(mockRequest);
-      assert.equal(data.form['opt_in_path[]'], mockRequest.body.opt_in_path);
-      assert.equal(data.form['person[first_name]'], mockRequest.body.first_name);
+      const data = WebActionsController.createMobileCommonsRequest(req);
+      assert.equal(data.form['opt_in_path[]'], req.body.opt_in_path);
+      assert.equal(data.form['person[first_name]'], req.body.first_name);
       assert.equal(data.form['person[referral_code]'], 'JkjrkLr');
-      assert.equal(data.form['friends_opt_in_path'], mockRequest.body.friends_opt_in_path);
-      assert.equal(data.form['friends[0][phone]'], mockRequest.body.friends[0].phone);
-      assert.equal(data.form['friends[0][first_name]'], mockRequest.body.friends[0].first_name);
-      assert.equal(data.form['friends[0][referral_code]'], 'qGl0G4r');
-      assert.equal(data.form['friends[1][phone]'], mockRequest.body.friends[1].phone);
-      assert.equal(data.form['friends[1][first_name]'], mockRequest.body.friends[1].first_name);
-      assert.equal(data.form['friends[1][referral_code]'], 'XZgVZpl');
-      assert.equal(data.form['friends[2][phone]'], mockRequest.body.friends[2].phone);
-      assert.equal(data.form['friends[2][first_name]'], mockRequest.body.friends[2].first_name);
-      assert.equal(data.form['friends[2][referral_code]'], '8WgrW5A');
+      assert.equal(
+        data.form['friends_opt_in_path'],
+        req.body.friends_opt_in_path
+      );
+      assert.equal(data.form['friends[0][phone]'], req.body.friends[0].phone);
+      assert.equal(data.form['friends[1][phone]'], req.body.friends[1].phone);
+      assert.equal(data.form['friends[2][phone]'], req.body.friends[2].phone);
     });
 
     it('should not add friends to the request if the friends_opt_in_path is missing', () => {
-      const mockRequest = {
+      const req = {
         body: {
           first_name: 'TEST_FNAME',
           phone: '3015550100',
@@ -91,14 +91,14 @@ describe('WebActionsController', () => {
         },
       };
 
-      const data = WebActionsController.createMobileCommonsRequest(mockRequest);
+      const data = WebActionsController.createMobileCommonsRequest(req);
       assert.equal(data.form['friends[0]'], undefined);
     });
   });
 
   describe('#createMobileCommonsReferralRequest', () => {
     it('should return false when no phone numbers are provided', () => {
-      const mockRequest = {
+      const req = {
         body: {
           phone: '3015550100',
           invitePhone1: null,
@@ -107,12 +107,12 @@ describe('WebActionsController', () => {
         },
       };
 
-      const data = WebActionsController.createMobileCommonsReferralRequest(mockRequest);
+      const data = WebActionsController.createMobileCommonsReferralRequest(req);
       assert.equal(data, false);
     });
 
     it('should handle building the request for 1 friend referral', () => {
-      const mockRequest = {
+      const req = {
         body: {
           phone: '3015550100',
           invitePhone1: '3015550101',
@@ -121,7 +121,7 @@ describe('WebActionsController', () => {
         },
       };
 
-      const data = WebActionsController.createMobileCommonsReferralRequest(mockRequest);
+      const data = WebActionsController.createMobileCommonsReferralRequest(req);
       assert.equal(typeof data, 'object');
       assert.equal(typeof data.form, 'object');
       assert.equal(
@@ -132,14 +132,14 @@ describe('WebActionsController', () => {
         data.form['friends_opt_in_path'],
         WebActionsController.MOBILE_COMMONS_INVITE_BETA_OPTIN
       );
-      assert.equal(data.form['friends[0]'], mockRequest.body.invitePhone1);
+      assert.equal(data.form['friends[0]'], req.body.invitePhone1);
       assert.equal(data.form['friends[1]'], undefined);
       assert.equal(data.form['friends[2]'], undefined);
       assert.equal(data.form['friends[0][referral_code]'], 'qGl0G4r');
     });
 
     it('should handle building the request for 2 friend referrals', () => {
-      const mockRequest = {
+      const req = {
         body: {
           phone: '3015550100',
           invitePhone1: '3015550101',
@@ -148,7 +148,7 @@ describe('WebActionsController', () => {
         },
       };
 
-      const data = WebActionsController.createMobileCommonsReferralRequest(mockRequest);
+      const data = WebActionsController.createMobileCommonsReferralRequest(req);
       assert.equal(typeof data, 'object');
       assert.equal(typeof data.form, 'object');
       assert.equal(
@@ -159,15 +159,15 @@ describe('WebActionsController', () => {
         data.form['friends_opt_in_path'],
         WebActionsController.MOBILE_COMMONS_INVITE_BETA_OPTIN
       );
-      assert.equal(data.form['friends[0]'], mockRequest.body.invitePhone1);
-      assert.equal(data.form['friends[1]'], mockRequest.body.invitePhone3);
+      assert.equal(data.form['friends[0]'], req.body.invitePhone1);
+      assert.equal(data.form['friends[1]'], req.body.invitePhone3);
       assert.equal(data.form['friends[2]'], undefined);
       assert.equal(data.form['friends[0][referral_code]'], 'qGl0G4r');
       assert.equal(data.form['friends[1][referral_code]'], '8WgrW5A');
     });
 
     it('should handle building the request for 3 friend referral', () => {
-      const mockRequest = {
+      const req = {
         body: {
           phone: '3015550100',
           invitePhone1: '3015550101',
@@ -176,7 +176,7 @@ describe('WebActionsController', () => {
         },
       };
 
-      const data = WebActionsController.createMobileCommonsReferralRequest(mockRequest);
+      const data = WebActionsController.createMobileCommonsReferralRequest(req);
       assert.equal(typeof data, 'object');
       assert.equal(typeof data.form, 'object');
       assert.equal(
@@ -187,9 +187,9 @@ describe('WebActionsController', () => {
         data.form['friends_opt_in_path'],
         WebActionsController.MOBILE_COMMONS_INVITE_BETA_OPTIN
       );
-      assert.equal(data.form['friends[0]'], mockRequest.body.invitePhone1);
-      assert.equal(data.form['friends[1]'], mockRequest.body.invitePhone2);
-      assert.equal(data.form['friends[2]'], mockRequest.body.invitePhone3);
+      assert.equal(data.form['friends[0]'], req.body.invitePhone1);
+      assert.equal(data.form['friends[1]'], req.body.invitePhone2);
+      assert.equal(data.form['friends[2]'], req.body.invitePhone3);
       assert.equal(data.form['friends[0][referral_code]'], 'qGl0G4r');
       assert.equal(data.form['friends[1][referral_code]'], 'XZgVZpl');
       assert.equal(data.form['friends[2][referral_code]'], '8WgrW5A');


### PR DESCRIPTION
#### What's this PR do?
It wasn't ever really advertised to the user on the homepage, but there were ways to get to Shine Talk from this app before. Namely going to a /talk or /shinevisor route. This PR removes those routes, their handling and related environment variables.

Going to those routes now will just give you a 404. 

Separately, fixed the unit tests that were failing after previous changes made to `WebActionsController.createMobileCommonsRequest()`.

#### What was tested?
Just confirming that trying to go to /talk or /shinevisor will result in the 404 page and that the removed environment variables weren't somehow used elsewhere in the app.