### PR TITLE
Updates oldest year available on bday form

### DIFF
--- a/assets/js/sms-settings.js
+++ b/assets/js/sms-settings.js
@@ -9,7 +9,7 @@ if (document.getElementById('bday-day')) {
 if (document.getElementById('bday-year')) {
   var date = new Date();
   var lastYear = date.getFullYear() - 13;
-  var firstYear = lastYear - 60;
+  var firstYear = lastYear - 87;
 
   var bdayYear = $('#bday-year');
   bdayYear.append('<option value="" selected="selected">--</option>');


### PR DESCRIPTION
#### What's this PR do?
Someone who's 100 years old will now be able to sign up for Shine Text and input their actual bday year. The previous max age someone could input their age at was 73.

#### How was this tested?
Can be verified by just going to the /sms-settings page

#### Fun Fact
This bug was reported by Haley's grandma.
