### PR TITLE
Updated app-store link on homepage app section

### DIFF
--- a/views/homepage.ejs
+++ b/views/homepage.ejs
@@ -139,7 +139,7 @@
       <div class="info">
         <h2>Introducing: Mindful Moments 🎧</h2>
         <p>We just launched a shiny new IOS app where you can listen to Mindful Moments — our take on meditations for <i>your</i> world. Check it out now!</p>
-        <a href="https://itunes.apple.com/us/app/shine-daily-motivation/id1293721589?mt=8" target="_blank">
+        <a href="https://go.onelink.me/Unhk?pid=Shine&c=Homepage" target="_blank">
           <img src="/images/app-page/LaunchPage-AppleStoreBadge-Mobile.png" />
         </a>
       </div>


### PR DESCRIPTION
#### What's this PR do?
Change homepage app link to a link provided by appsflyer. This change gives us the ability to track users who convert from `shinetext.com`  on the  appsflyer dashboard. 