### PR TITLE
Jobs page update

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "bluebird": "^3.4.1",
     "crypto": "^1.0.1",
     "dotenv": "^2.0.0",
-    "ejs": "2.3.4",
+    "ejs": "2.5.5",
     "grunt": "0.4.5",
     "grunt-contrib-clean": "0.6.0",
     "grunt-contrib-coffee": "0.13.0",
@@ -39,7 +39,8 @@
   "scripts": {
     "debug": "node debug app.js",
     "start": "node app.js",
-    "test": "NODE_ENV=test mocha test/bootstrap.test.js test/integration/**/*.test.js"
+    "test":
+      "NODE_ENV=test mocha test/bootstrap.test.js test/integration/**/*.test.js"
   },
   "main": "app.js",
   "devDependencies": {

--- a/views/jobs.ejs
+++ b/views/jobs.ejs
@@ -1,17 +1,7 @@
 <div class="col-xs-10 col-xs-offset-1 col-md-8 col-md-offset-2">
-  <h1>Come work with us!</h1>
+    <h1>Come work with us!</h1>
 
-  <script type="text/javascript" id="rbox-loader-script">
-  if(!window._rbox){
-  _rbox = { host_protocol:document.location.protocol, ready:function(cb){this.onready=cb;} };
-  (function(d, e) {
-      var s, t, i, src=['/static/client-src-served/widget/62960/rbox_api.js', '/static/client-src-served/widget/62960/rbox_impl.js'];
-      t = d.getElementsByTagName(e); t=t[t.length - 1];
-      for(i=0; i<src.length; i++) {
-          s = d.createElement(e); s.src = _rbox.host_protocol + '//w.recruiterbox.com' + eval("src" + String.fromCharCode(91) + String(i) + String.fromCharCode(93));
-          t.parentNode.insertBefore(s, t.nextSibling);
-      }})(document, 'script');
-  }
-  </script>
-
+    <div style="text-align:center">
+        <a class="btn" style="max-width:300px" href="https://shinetext.workable.com/">View Job Openings</a>
+    </div>
 </div>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -1,37 +1,41 @@
 <footer>
   <% if (typeof hideFooterCta === 'undefined' || ! hideFooterCta) { %>
-  <div class="footer-cta">
-    <div class="cta-copy">Sign up for a free, daily motivational text message to make your morning better.</div>
-    <% if (typeof view !== 'undefined' && view === 'homepage') { %>
-    <a href="#" onclick="window.scrollTo(0,0);"><div class="signup-button">Sign Up</div></a>
-    <% } else  { %>
-    <a href="/"><div class="signup-button">Sign Up</div></a>
+    <div class="footer-cta">
+      <div class="cta-copy">Sign up for a free, daily motivational text message to make your morning better.</div>
+      <% if (typeof view !== 'undefined' && view === 'homepage') { %>
+        <a href="#" onclick="window.scrollTo(0,0);">
+          <div class="signup-button">Sign Up</div>
+        </a>
+        <% } else  { %>
+          <a href="/">
+            <div class="signup-button">Sign Up</div>
+          </a>
+          <% } %>
+    </div>
     <% } %>
-  </div>
-  <% } %>
-  <div class="social-and-footer-nav">
-    <div class="-social-icons">
-      <a class="-icon-facebook" href="https://www.facebook.com/Shine-Text" target="_blank"></a>
-      <a class="-icon-instagram" href="https://instagram.com/ShineText" target="_blank"></a>
-      <a class="-icon-twitter" href="https://twitter.com/ShineText" target="_blank"></a>
-    </div>
-    <div class="page-links">
-      <a href="/advice">Get Advice</a>
-      <a href="/referrals">Invite Friends</a>
-      <a href="/squad">The Squad</a>
-      <a href="/jobs">Careers</a>
-      <a href="/faq">FAQ</a>
-      <a href="/privacy-policy">Privacy Policy</a>
-      <a href="/terms-of-service">Terms of Service</a>
-    </div>
-  </div>
+      <div class="social-and-footer-nav">
+        <div class="-social-icons">
+          <a class="-icon-facebook" href="https://www.facebook.com/Shine-Text" target="_blank"></a>
+          <a class="-icon-instagram" href="https://instagram.com/ShineText" target="_blank"></a>
+          <a class="-icon-twitter" href="https://twitter.com/ShineText" target="_blank"></a>
+        </div>
+        <div class="page-links">
+          <a href="/advice">Get Advice</a>
+          <a href="/referrals">Invite Friends</a>
+          <a href="/squad">The Squad</a>
+          <a href="https://shinetext.workable.com/">Careers</a>
+          <a href="/faq">FAQ</a>
+          <a href="/privacy-policy">Privacy Policy</a>
+          <a href="/terms-of-service">Terms of Service</a>
+        </div>
+      </div>
 </footer>
 
 <!-- @todo HACK: remove the footer's top margin when the footer-cta isn't displayed -->
 <% if (typeof hideFooterCta !== 'undefined' && hideFooterCta) { %>
-<style>
-footer {
-  margin-top: 0;
-}
-</style>
-<% } %>
+  <style>
+    footer {
+      margin-top: 0;
+    }
+  </style>
+  <% } %>


### PR DESCRIPTION
### What's this PR do?
- Content on /jobs page is now just a button to our Workable jobs page
- The "Careers" link in the footer goes straight to the Workable page instead of requiring the user to do the extra click through on our /jobs page
- Updates ejs version. Github flagged 2.3.4 as having security vulnerabilities.

### Review notes
The footer.ejs change is really just this line:
```
<a href="https://shinetext.workable.com/">Careers</a>
```
Everything else in that file is the result of a Prettier pass.

### How was this tested?
All just local testing:
- tested the "Careers" link in the footer of homepage and subpages
- tested button on /jobs page
- visually checked homepage and a couple subpages to confirm nothing seemed to have changed from the ejs upgrade
