### PR TITLE
Updates links to the jobs page

### DIFF
--- a/views/jobs.ejs
+++ b/views/jobs.ejs
@@ -2,6 +2,6 @@
     <h1>Come work with us!</h1>
 
     <div style="text-align:center">
-        <a class="btn" style="max-width:300px" href="https://shinetext.workable.com/">View Job Openings</a>
+        <a class="btn" style="max-width:300px" href="https://careers.shinetext.com/">View Job Openings</a>
     </div>
 </div>

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -23,7 +23,7 @@
           <a href="/advice">Get Advice</a>
           <a href="/referrals">Invite Friends</a>
           <a href="/squad">The Squad</a>
-          <a href="https://shinetext.workable.com/">Careers</a>
+          <a href="/jobs">Careers</a>
           <a href="/faq">FAQ</a>
           <a href="/privacy-policy">Privacy Policy</a>
           <a href="/terms-of-service">Terms of Service</a>


### PR DESCRIPTION
#### What's this PR do?
- Updates the link in the footer to go back to `/jobs`
- Updates the link in the jobs.ejs template too, though in practice it's not actually being used right now

I've updated the `JOBS_REDIRECT_URL` environment variable on our server instance to point to the `careers.` subdomain. And we've already got it setup in the app (https://github.com/shinetext/aurora/blob/jobs/api/controllers/WebViewController.js#L42) that traffic to /jobs will redirect to the url set in that env var.

#### How was this tested?
Verified footer and direct traffic to /jobs went to the env var URL through local testing.

#### What are the relevant tickets?
https://trello.com/c/BXIeLJq8
