### PR TITLE
Optional email and button copy on partner pages

### DIFF
--- a/views/components/AlphaSignUpForm.js
+++ b/views/components/AlphaSignUpForm.js
@@ -2,6 +2,19 @@ import React from 'react';
 import FormField from './FormField';
 
 const AlphaSignUpForm = props => {
+  let emailField;
+  if (props.emailRequired) {
+    emailField = (
+      <FormField
+        isRequired
+        label="Email"
+        type="email"
+        fieldName="email"
+        value=""
+      />
+    );
+  }
+
   return (
     <div className="AlphaSignUpForm">
       <FormField
@@ -18,6 +31,7 @@ const AlphaSignUpForm = props => {
         fieldName="phone"
         value=""
       />
+      {emailField}
       <FormField type="hidden" fieldName="opt_in_path" value={props.optin} />
     </div>
   );

--- a/views/components/PartnerApp.js
+++ b/views/components/PartnerApp.js
@@ -14,6 +14,7 @@ class PartnerApp extends React.Component {
       additionalFormLink,
       betaCount,
       alphaEmailRequired,
+      signUpButtonText,
     } = this.props;
     const formDetails = {
       header: `${name}`,
@@ -24,6 +25,7 @@ class PartnerApp extends React.Component {
       additionalLink: additionalFormLink,
       betaCount,
       alphaEmailRequired,
+      signUpButtonText,
     };
 
     return (

--- a/views/components/PartnerApp.js
+++ b/views/components/PartnerApp.js
@@ -13,6 +13,7 @@ class PartnerApp extends React.Component {
       additionalFields,
       additionalFormLink,
       betaCount,
+      alphaEmailRequired,
     } = this.props;
     const formDetails = {
       header: `${name}`,
@@ -21,7 +22,8 @@ class PartnerApp extends React.Component {
       betaOptInPath: campaignKeyBeta,
       extras: additionalFields,
       additionalLink: additionalFormLink,
-      betaCount: betaCount,
+      betaCount,
+      alphaEmailRequired,
     };
 
     return (

--- a/views/components/SignUpForm.js
+++ b/views/components/SignUpForm.js
@@ -13,7 +13,8 @@ const SignUpForm = props => {
     betaOptInPath,
     extras,
     additionalLink,
-    betaCount
+    betaCount,
+    alphaEmailRequired,
   } = props;
 
   let infoView;
@@ -26,7 +27,10 @@ const SignUpForm = props => {
   let alphaView;
   if (!hideAlpha) {
     alphaView = (
-      <AlphaSignUpForm optin={PartnerService.getOptInPath(partnerId)} />
+      <AlphaSignUpForm
+        optin={PartnerService.getOptInPath(partnerId)}
+        emailRequired={alphaEmailRequired}
+      />
     );
   }
 
@@ -64,10 +68,15 @@ const SignUpForm = props => {
   return (
     <div className="SignUpForm col-md-7">
       <div className="container-signup">
-        <h2 dangerouslySetInnerHTML={{ __html: header}} />
+        <h2 dangerouslySetInnerHTML={{ __html: header }} />
         {infoView}
 
-        <form class="signup-form" id="alpha-signup" action="/join" method="post">
+        <form
+          class="signup-form"
+          id="alpha-signup"
+          action="/join"
+          method="post"
+        >
           {alphaView}
           {betaView}
           {extrasView}

--- a/views/components/SignUpForm.js
+++ b/views/components/SignUpForm.js
@@ -15,6 +15,7 @@ const SignUpForm = props => {
     additionalLink,
     betaCount,
     alphaEmailRequired,
+    signUpButtonText,
   } = props;
 
   let infoView;
@@ -91,7 +92,7 @@ const SignUpForm = props => {
               is
               class="btn"
               type="submit"
-              value="Get Shine Texts"
+              value={signUpButtonText || 'Get Shine Texts'}
               ga-on="click"
               ga-event-category="SignUp"
               ga-event-action="SMS"


### PR DESCRIPTION
#### What's this PR do?
Adds more configuration options to partner pages
- email field can be required by adding `alphaEmailRequired: true`
- copy on the sign up button can be customized by setting `signUpButtonText: "NEW COPY"`

#### How was this tested? How should this be reviewed?
Tested locally with a test partner config. A PR will come later with the actual config for the upcoming campaign.

#### What are the relevant tickets?
https://trello.com/c/LCRc3kKG/40-shine-girlboss-sweeps-page