### PR TITLE
add more logs to /join to track how users make referral and how data …

### DIFF
--- a/api/controllers/WebActionsController.js
+++ b/api/controllers/WebActionsController.js
@@ -213,6 +213,14 @@ module.exports = {
    * POST /join
    */
   join: function(req, res) {
+    sails.log.info(
+      `Beta's JOIN request: ${req.headers.referer} ${JSON.stringify(
+        req.body,
+        null,
+        2
+      )}`
+    );
+
     let redirectUrl;
 
     // If signing up through partner landing pages, redirect directly to
@@ -317,9 +325,8 @@ module.exports = {
                   'Invalid response received from Photon GET referral/:phone.'
                 );
               } else {
-                sails.log.info('Successful GET referral count');
                 sails.log.info(
-                  `  referralCount: ${resData.body.referralCount}`
+                  `Successful GET referral count: ${resData.body.referralCount}`
                 );
 
                 let referralData = {
@@ -333,14 +340,12 @@ module.exports = {
                     platformId: resData.body.id,
                     referralCode: req.body.referredByCode,
                     referralCount: resData.body.referralCount,
+                    phone: referrerPhone,
                   },
                 };
                 sails.log.info(`${
                   req.body.first_name
-                } just signed up and was referred by ${
-                  referralData.referrer.platformId
-                },
-                  who made ${referralData.referrer.referralCount} referrals.
+                } just signed up. ${JSON.stringify(referralData, null, 2)}
                   Publishing SNS event...`);
 
                 SnsService.publishEvent(
@@ -350,7 +355,7 @@ module.exports = {
               }
             })
             .catch(err => {
-              sails.log.error(err);
+              sails.log.error(`Error getting Referral Count ${err}`);
             });
         }
 

--- a/api/controllers/WebActionsController.js
+++ b/api/controllers/WebActionsController.js
@@ -340,12 +340,15 @@ module.exports = {
                     platformId: resData.body.id,
                     referralCode: req.body.referredByCode,
                     referralCount: resData.body.referralCount,
-                    phone: referrerPhone,
                   },
                 };
                 sails.log.info(`${
                   req.body.first_name
-                } just signed up. ${JSON.stringify(referralData, null, 2)}
+                } with phone # ${referrerPhone} just signed up. ${JSON.stringify(
+                  referralData,
+                  null,
+                  2
+                )}
                   Publishing SNS event...`);
 
                 SnsService.publishEvent(


### PR DESCRIPTION
…is packaged for SNS pub

#### What's this PR do?
- Seeing weird EARLY_EXIT errors in dashbird for lambda (messageOnReferralMilestone) in Beacon  that is subscribed to the SNS event published in Aurora.
- Most of these errors are pointing to missing properties in the data that is sent to Beacon. 
- Adding logs to Aurora in hopes to get more understanding of how these errors are created / where these errors are coming from / potential solution?

#### How was this tested? How should this be reviewed?
Specific things to look out for or test

#### What are the relevant tickets?
Relevant Github issues

#### Questions / Considerations
Additional context needed or things to consider
