### PR TITLE
Adds partner page for The Nod

### DIFF
--- a/api/controllers/WebViewController.js
+++ b/api/controllers/WebViewController.js
@@ -349,7 +349,7 @@ module.exports = {
     }`;
 
     const twitterShareBody =
-      'A text that sends you a daily self-care advice? Yes, please. Join me %26 sign up for Shine! %23ShineOn';
+      'A text that sends you daily self-care advice? Yes, please. Join me %26 sign up for Shine! %23ShineOn';
     const smsShareBody =
     'Hey! I just signed up for Shine %26 thought you would love this - Shine sends a free, daily motivational text message to make your morning better. Sign up with my link here:';
     const emailShareTitle = "Thought you'd like this!";

--- a/api/controllers/WebViewController.js
+++ b/api/controllers/WebViewController.js
@@ -39,9 +39,14 @@ module.exports = {
     return res.redirect(301, '/jobs');
   },
 
+  nod: (req, res) => {
+    return res.redirect(301, '/p/nod');
+  },
+
   jobs: (req, res) => {
     return res.redirect(302, `${sails.config.globals.jobsRedirectUrl}`);
   },
+
   /**
    * Redirect to the Daily Shine homepage.
    */
@@ -351,7 +356,7 @@ module.exports = {
     const twitterShareBody =
       'A text that sends you daily self-care advice? Yes, please. Join me %26 sign up for Shine! %23ShineOn';
     const smsShareBody =
-    'Hey! I just signed up for Shine %26 thought you would love this - Shine sends a free, daily motivational text message to make your morning better. Sign up with my link here:';
+      'Hey! I just signed up for Shine %26 thought you would love this - Shine sends a free, daily motivational text message to make your morning better. Sign up with my link here:';
     const emailShareTitle = "Thought you'd like this!";
     const emailShareBody =
       'Hey! Thought you would love this - Shine sends a free, daily motivational text message to make your morning better. Sign up with my link here: ';

--- a/api/services/partnersData.js
+++ b/api/services/partnersData.js
@@ -156,6 +156,16 @@ const partnersData = {
         'https://advice.shinetext.com/tags/all-the-feels/?utm_source=Shine&utm_medium=PartnerPage&utm_campaign=AllTheFeels',
     },
   },
+  nod: {
+    name: 'A daily text to help you thrive',
+    imageUrl: '/images/homepage/homepage_photo_1.jpg',
+    copy: '<p>Join over 2M people who start their morning with Shine.</p>',
+    confirmation: {
+      imageUrl: '/images/confirmation-header-happy-dance.gif',
+      copy: "You're all signed up!",
+    },
+    campaignKey: 'OP6DF7962B5D3CCC7F635D6BCD6713F25A',
+  },
   wybmn: {
     name: 'Get texts from Shine inspired by Mr. Rogers',
     imageUrl: '/images/partners/mr-rogers-shine.png',

--- a/api/services/partnersData.js
+++ b/api/services/partnersData.js
@@ -75,19 +75,15 @@ const partnersData = {
     campaignKey: process.env.SNAPCHAT_MOBILECOMMONS_KEY,
   },
   'self-care-scholarship-2017': {
-    name: '$500 Easy Self-Care Scholarship - Winter 2018',
+    name: 'The $500 Self-Care Scholarship is no longer running.',
     imageUrl: '/images/partners/scholarship/scholarship-2017-photo.jpg',
     copy:
-      '<p>School can be stressful.</p><p>Sign up to get a free daily text message to help you practice self-care AND get a chance to earn cash for school.</p><p>To enter the $500 scholarship, sign up for <a href="/?utm_source=Shine&utm_medium=Scholarship">Shine</a> texts.</p><p><a href="/images/partners/scholarship/scholarship-winner-denisse.png">Previous Scholarship Winner</a></p>',
+      'However, you can sign up to get a free daily text message from Shine to help you practice self-care and stress less this school year.',
     confirmation: {
       imageUrl: '/images/partners/scholarship/confirmation.gif',
       copy: 'You’ve entered the Shine Self-Care Scholarship!',
     },
-    campaignKey: 'OPF103C6C3AE571FD2082D4B7F18929F5B',
-    additionalFormLink: {
-      label: 'Official Scholarship Rules',
-      link: '/files/Scholarship-Rules-2-7-18.pdf',
-    },
+    campaignKey: 'OPB1AA249928CF5621FE3CA64715CB1B44',
   },
   'summersweeps-girlboss': {
     name: 'Treat yourself this summer with $1,000 from Shine & Girlboss',

--- a/config/routes.js
+++ b/config/routes.js
@@ -32,19 +32,21 @@ var routes = {
    ***************************************************************************/
 
   '/': 'WebViewController.home',
-  '/home': 'WebViewController.home',
-
+  '/500': {
+    view: '500',
+  },
+  '/app': 'WebViewController.app',
   '/advice': 'WebViewController.advice',
   '/articles': 'WebViewController.advice',
   '/articles/*': 'WebViewController.articlesRedirect',
-
+  '/c/:campaign': 'WebViewController.campaigns',
+  '/c/:campaign/share': 'WebViewController.campaignReferral',
+  '/campaigns/:campaign': 'WebViewController.campaigns',
+  '/campaigns/:campaign/share': 'WebViewController.campaignReferral',
   '/careers': 'WebViewController.careers',
-  '/jobs': 'WebViewController.jobs',
-
+  '/coming-soon': 'WebViewController.splash',
   '/confirmation': 'WebViewController.confirmation',
-
   '/daily': 'WebViewController.daily',
-
   '/faq': {
     view: 'faq',
     locals: {
@@ -52,18 +54,11 @@ var routes = {
       layout: 'layouts/subpage.layout',
     },
   },
-
+  '/home': 'WebViewController.home',
+  '/jobs': 'WebViewController.jobs',
+  '/nod': 'WebViewController.nod',
   '/p/:partner': 'WebViewController.partners',
   '/partners/:partner': 'WebViewController.partners',
-
-  '/app': 'WebViewController.app',
-  '/coming-soon': 'WebViewController.splash',
-
-  '/campaigns/:campaign': 'WebViewController.campaigns',
-  '/campaigns/:campaign/share': 'WebViewController.campaignReferral',
-  '/c/:campaign': 'WebViewController.campaigns',
-  '/c/:campaign/share': 'WebViewController.campaignReferral',
-
   '/privacy-policy': {
     view: 'privacy-policy',
     locals: {
@@ -71,7 +66,6 @@ var routes = {
       layout: 'layouts/subpage.layout',
     },
   },
-
   '/referrals': {
     view: 'referrals',
     locals: {
@@ -81,9 +75,16 @@ var routes = {
       headerText: 'Shine with friends!',
     },
   },
-
   '/referrals/:phone': 'WebViewController.myReferral',
-
+  '/sms-settings': 'WebViewController.smsSettings',
+  '/speakers': {
+    view: 'speakers',
+    locals: {
+      title: 'Speakers | Shine',
+      layout: 'layouts/subpage.layout',
+    },
+  },
+  '/squad': 'WebViewController.squad',
   '/swag': {
     view: 'swag-page',
     locals: {
@@ -92,19 +93,6 @@ var routes = {
       hideFooterCta: true,
     },
   },
-
-  '/sms-settings': 'WebViewController.smsSettings',
-
-  '/speakers': {
-    view: 'speakers',
-    locals: {
-      title: 'Speakers | Shine',
-      layout: 'layouts/subpage.layout',
-    },
-  },
-
-  '/squad': 'WebViewController.squad',
-
   '/terms-of-service': {
     view: 'terms-of-service',
     locals: {
@@ -112,7 +100,6 @@ var routes = {
       layout: 'layouts/subpage.layout',
     },
   },
-
   '/try-messenger': {
     view: 'try-messenger',
     locals: {
@@ -120,11 +107,6 @@ var routes = {
       layout: 'layouts/subpage.layout',
     },
   },
-
-  '/500': {
-    view: '500',
-  },
-
   '/year1': {
     view: 'year1',
     locals: {


### PR DESCRIPTION
#### What's this PR do?
- Adds config for a /nod partner page. Basically the same as the `igs` config but with a different MC opt-in path (which is already setup).
- Sets up redirect from `/nod` to `/p/nod`. And while doing this, also alphabetized the routes in routes.js
- Fixes typo in Twitter share copy

#### How was this tested? How should this be reviewed?
Local testing. Verified:
- `/nod` redirects to `/p/nod`
- sign up on the nod page
- all subpages linked from the header and footer still work

#### What are the relevant tickets?
- https://trello.com/c/E5uFSeLe
- https://trello.com/c/EhgFnCid
