### PR TITLE
Update cdn for bootstrap + font-awesome in html header to stackpath

### DIFF
--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -19,9 +19,8 @@
   <!-- Fonts -->
   <link href="https://fonts.googleapis.com/css?family=Caveat+Brush" rel="stylesheet" type="text/css">
 
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" integrity="sha384-1q8mTJOASx8j1Au+a5WDVnPi2lkFfwwEAa8hDDdjZlpLegxhjVME1fgjWPGmkzs7"
-    crossorigin="anonymous">
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
 
   <!--STYLES-->
   <link rel="stylesheet" href="/styles/importer.css">


### PR DESCRIPTION
#### What's this PR do?
Update cdn for bootstrap + font-awesome in html header from maxcdn --> stackpath

#### How was this tested? How should this be reviewed?
locally host and checking styles on each page

#### What are the relevant tickets?
Bug found by Christopher Sancho

#### Questions / Considerations
- Wasn't sure if we still needed to set `integrity=...` and `crossorigin="anonymous"` attributes to the tag for bootstrap? It works fine locally without it but wondering if there's a historical reasoning behind it.

- Updating to the latest version of bootstrap threw off the styles, so have retained the version we were using which 3.3.6.
- I did notice that even the stackpath cdn was also taking awhile to load the script at one point, though that seems to have gone away and haven't been able to reproduce since. 


