### PR TITLE
Bump bootstrap version from 3.3.6 to 3.3.7

### DIFF
--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -19,7 +19,7 @@
   <!-- Fonts -->
   <link href="https://fonts.googleapis.com/css?family=Caveat+Brush" rel="stylesheet" type="text/css">
 
-  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
 
   <!--STYLES-->


### PR DESCRIPTION
#### What's this PR do?
Because the bootstrap cdn seems to have problems loading specifically version `3.3.6` of the library, we're bumping bootstrap version from 3.3.6 to 3.3.7.  

#### How was this tested? How should this be reviewed?
Locally - no noticeable impact on styling.