### PR TITLE
add email field to homepage

### DIFF
--- a/assets/styles/pages/homepage.less
+++ b/assets/styles/pages/homepage.less
@@ -35,8 +35,8 @@ font-size: @font-size-homepage-normal;
     }
 
     .form-container {
-      width: 412px;
-      height: 358px;
+      width: 496px;
+      height: 440px;
       background-color: white;
       margin: auto;
       border-radius: 20px;

--- a/views/homepage.ejs
+++ b/views/homepage.ejs
@@ -33,6 +33,12 @@
             <span class="required-asterisk">*</span>
           </div>
 
+          <div class="form-field">
+            <input class="form-control" name="email" id="form-email" type="email" required value="">
+            <label for="form-email">Email</label>
+            <span class="required-asterisk">*</span>
+          </div>
+
           <div>
             <input class="btn" type="submit" value="Get Shine Texts"
               ga-on="click"


### PR DESCRIPTION
#### What's this PR do?
- add email field (required) to signup box in homepage

#### How was this tested? How should this be reviewed?
- Tested locally by pointing app to local database. When I signup as a new and or existing user on the homepage, my email is saved in to local database

#### What are the relevant tickets?
[https://trello.com/c/bjY2090r/173-add-email-back-to-the-site-when-people-sign-up-for-sms(url)

#### Questions / Considerations
- I believe the join function already 1) save user email to db, 2) create or update mc profile with email, and 3) add user email to mailchimp. it was a matter of adding the field to the form and making sure the value is sent to the join endpoint
