### PR TITLE
Closes the GirlBoss giveaway pages

### DIFF
--- a/api/services/partnersData.js
+++ b/api/services/partnersData.js
@@ -15,6 +15,9 @@
  *    campaignKeyBeta: 'Optional key for signing up beta users',
  *     betaCount: Number controling the amount of referral input fields to display,
  *    },
+ *    alphaEmailRequired: true/false, // Optional. Add email input field to the signup form
+ *    signUpButtonText: 'Enter', // Optional. Customized text on the submit button
+ *    hideForm: true/false, // Optional. Hides the signup form if set to true
  * }
  */
 const partnersData = {
@@ -86,7 +89,7 @@ const partnersData = {
     campaignKey: 'OPB1AA249928CF5621FE3CA64715CB1B44',
   },
   'summersweeps-girlboss': {
-    name: 'Treat yourself this summer with $1,000 from Shine & Girlboss',
+    name: 'This giveaway is no longer running',
     imageUrl: '/images/partners/girlboss-giveaway.jpg',
     copy:
       '<p>Self-care isn’t just face masks and bubble baths—it means something different to everyone. This summer, snag some extra cash from Shine & Girlboss to help you practice your style of self-care. Whether it’s a weekend getaway with the VIPs in your life or paying off bills, we got you. </p><p>Enter to win $1,000 plus, a free year long subscription to the <a href="https://go.onelink.me/app/219fc510"/>Shine app</a> & the Girlboss Academy to inspire you all year long.</p>',
@@ -101,9 +104,10 @@ const partnersData = {
     campaignKey: 'OP39C0317FB30329CE81C46936C5DFE198',
     alphaEmailRequired: true,
     signUpButtonText: 'Enter',
+    hideForm: true,
   },
   'summersweeps-shine': {
-    name: 'Treat yourself this summer with $1,000 from Shine & Girlboss',
+    name: 'This giveaway is no longer running',
     imageUrl: '/images/partners/girlboss-giveaway.jpg',
     copy:
       '<p>Self-care isn’t just face masks and bubble baths—it means something different to everyone. This summer, snag some extra cash from Shine & Girlboss to help you practice your style of self-care. Whether it’s a weekend getaway with the VIPs in your life or paying off bills, we got you. </p><p>Enter to win $1,000 plus, a free year long subscription to the <a href="https://go.onelink.me/app/219fc510"/>Shine app</a> & the Girlboss Academy to inspire you all year long.</p>',
@@ -118,6 +122,7 @@ const partnersData = {
     campaignKey: 'OP57EC434BD4A0CC3EFC5CB959EF7D9824',
     alphaEmailRequired: true,
     signUpButtonText: 'Enter',
+    hideForm: true,
   },
   'valentines-day': {
     name: 'Be your own boo.',

--- a/views/components/PartnerApp.js
+++ b/views/components/PartnerApp.js
@@ -14,6 +14,7 @@ class PartnerApp extends React.Component {
       additionalFormLink,
       betaCount,
       alphaEmailRequired,
+      hideForm,
       signUpButtonText,
     } = this.props;
     const formDetails = {
@@ -25,6 +26,7 @@ class PartnerApp extends React.Component {
       additionalLink: additionalFormLink,
       betaCount,
       alphaEmailRequired,
+      hideForm,
       signUpButtonText,
     };
 

--- a/views/components/SignUpForm.js
+++ b/views/components/SignUpForm.js
@@ -9,7 +9,7 @@ const SignUpForm = props => {
     header,
     info,
     partnerId,
-    hideAlpha,
+    hideForm,
     betaOptInPath,
     extras,
     additionalLink,
@@ -25,15 +25,12 @@ const SignUpForm = props => {
     );
   }
 
-  let alphaView;
-  if (!hideAlpha) {
-    alphaView = (
-      <AlphaSignUpForm
-        optin={PartnerService.getOptInPath(partnerId)}
-        emailRequired={alphaEmailRequired}
-      />
-    );
-  }
+  const alphaView = (
+    <AlphaSignUpForm
+      optin={PartnerService.getOptInPath(partnerId)}
+      emailRequired={alphaEmailRequired}
+    />
+  );
 
   let betaView;
   if (betaOptInPath) {
@@ -57,6 +54,35 @@ const SignUpForm = props => {
     }
   }
 
+  let webform;
+  if (!hideForm) {
+    webform = (
+      <form class="signup-form" id="alpha-signup" action="/join" method="post">
+        {alphaView}
+        {betaView}
+        {extrasView}
+
+        <FormField
+          type="hidden"
+          fieldName="partner"
+          value={partnerId ? partnerId : null}
+        />
+        <div>
+          <input
+            is
+            class="btn"
+            type="submit"
+            value={signUpButtonText || 'Get Shine Texts'}
+            ga-on="click"
+            ga-event-category="SignUp"
+            ga-event-action="SMS"
+            ga-event-label={partnerId}
+          />
+        </div>
+      </form>
+    );
+  }
+
   let additionalLinkView;
   if (additionalLink) {
     additionalLinkView = (
@@ -71,35 +97,7 @@ const SignUpForm = props => {
       <div className="container-signup">
         <h2 dangerouslySetInnerHTML={{ __html: header }} />
         {infoView}
-
-        <form
-          class="signup-form"
-          id="alpha-signup"
-          action="/join"
-          method="post"
-        >
-          {alphaView}
-          {betaView}
-          {extrasView}
-
-          <FormField
-            type="hidden"
-            fieldName="partner"
-            value={partnerId ? partnerId : null}
-          />
-          <div>
-            <input
-              is
-              class="btn"
-              type="submit"
-              value={signUpButtonText || 'Get Shine Texts'}
-              ga-on="click"
-              ga-event-category="SignUp"
-              ga-event-action="SMS"
-              ga-event-label={partnerId}
-            />
-          </div>
-        </form>
+        {webform}
         <Disclaimer />
         {additionalLinkView}
       </div>


### PR DESCRIPTION
#### What's this PR do?
- Adds hideForm option when configuring partner data to hide the sign up form
- Removed SignUpForm.hideAlpha since it didn't seem to be used anywhere

#### How was this tested?
Local testing across different partner pages and verifying forms were showing or not as expected.

#### What are the relevant tickets?
https://trello.com/c/AUpaLkec/188-close-girlboss-giveaway