### PR TITLE
Add app CTA button to before signup form

### DIFF
--- a/assets/styles/pages/homepage.less
+++ b/assets/styles/pages/homepage.less
@@ -20,18 +20,35 @@ font-size: @font-size-homepage-normal;
   }
   .container-signup {
     height: @container-homepage-lead-height;
-    padding-bottom: @margin-lg;
-    padding-top: @margin-lg;
+    padding-bottom: 80px;
+    padding-top: 20px;
 
     h2 {
       .font-Poppins;
       font-size: (@font-size-header - 6);
       color: #333;
-      margin: @margin-md auto @margin-lg auto;
+      margin: 0px auto 30px auto;
       line-height: 54px;
       letter-spacing: 1px;
       text-align: center;
       width: 598px;
+    }
+    .signup-download-container {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      width: 100%;
+      height: auto;
+      margin: 0px 0px 50px 0px;
+    }
+    .signup-download-button-img {
+      width: 100%;
+      align-self: center;
+    }
+
+    .signup-download-button-link {
+      max-width: 185px;
+      align-self: center;
     }
 
     .form-container {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "shine-aurora",
   "private": true,
-  "version": "1.12.6",
+  "version": "1.12.7",
   "description": "",
   "keywords": [],
   "dependencies": {

--- a/views/homepage.ejs
+++ b/views/homepage.ejs
@@ -4,173 +4,191 @@
 
   <%- partial ('partials/navbar.ejs') %>
 
-    <div class="container-fluid">
+  <div class="container-fluid">
 
-    </div>
-    <!-- Top sign up section -->
-    <div class="container-fluid container-homepage-lead">
-      <div class="col-md-7">
-        <div class="container-signup">
-          <h2>A morning self-care text to help you run the day.</h2>
-          <div class="form-container">
-            <form action="/join" method="post">
+  </div>
+  <!-- Top sign up section -->
+  <div class="container-fluid container-homepage-lead">
+    <div class="col-md-7">
+      <div class="container-signup">
+        <h2>A morning self-care reminder to help you run the day.</h2>
 
-              <% if (referredByCode) { %><input name="referredByCode" value="<%= referredByCode %>" type="hidden" /><% } %>
-                  <% if (utmCampaign) { %><input name="utmCampaign" value="<%= utmCampaign %>" type="hidden" /><% } %>
-                      <% if (utmContent) { %><input name="utmContent" value="<%= utmContent %>" type="hidden" /><% } %>
-                          <% if (utmSource) { %><input name="utmSource" value="<%= utmSource %>" type="hidden" /><% } %>
-                              <% if (utmMedium) { %><input name="utmMedium" value="<%= utmMedium %>" type="hidden" /><% } %>
+        <div class="signup-download-container">
+          <a class="signup-download-button-link" href="https://shineapp.onelink.me/Unhk/5e843550">
+            <img class="signup-download-button-img" src="/images/app-page/LaunchPage-AppleStoreBadge-Mobile.png" />
+          </a>
+        </div>
 
-                                  <div class="form-field">
-                                    <input class="form-control" name="first_name" id="form-first-name" type="text" required value="">
-                                    <label for="form-first-name">First Name</label>
-                                    <span class="required-asterisk">*</span>
-                                  </div>
+        <div class="form-container">
+          <form action="/join" method="post">
 
-                                  <div class="form-field">
-                                    <input class="form-control" name="phone" id="form-phone-number" type="tel" required value="">
-                                    <label for="form-phone-number">Phone Number</label>
-                                    <span class="required-asterisk">*</span>
-                                  </div>
+            <% if (referredByCode) { %><input name="referredByCode" value="<%= referredByCode %>" type="hidden" />
+            <% } %>
+            <% if (utmCampaign) { %><input name="utmCampaign" value="<%= utmCampaign %>" type="hidden" />
+            <% } %>
+            <% if (utmContent) { %><input name="utmContent" value="<%= utmContent %>" type="hidden" />
+            <% } %>
+            <% if (utmSource) { %><input name="utmSource" value="<%= utmSource %>" type="hidden" />
+            <% } %>
+            <% if (utmMedium) { %><input name="utmMedium" value="<%= utmMedium %>" type="hidden" />
+            <% } %>
 
-                                  <div class="form-field">
-                                    <input class="form-control" name="email" id="form-email" type="email" required value="">
-                                    <label for="form-email">Email</label>
-                                    <span class="required-asterisk">*</span>
-                                  </div>
-
-                                  <div>
-                                    <input class="btn" type="submit" value="Get Shine Texts" ga-on="click" ga-event-category="SignUp" ga-event-action="SMS" />
-                                  </div>
-            </form>
-            <div class="ctia">
-              Signing up means you agree to our <a href="/terms-of-service">Terms of Service</a>
-              & <a href="/privacy-policy">Privacy Policy</a> and to receive our daily message. Message & data rates may apply.
-              Text STOP to opt-out, HELP for help.
+            <div class="form-field">
+              <input class="form-control" name="first_name" id="form-first-name" type="text" required value="">
+              <label for="form-first-name">First Name</label>
+              <span class="required-asterisk">*</span>
             </div>
+
+            <div class="form-field">
+              <input class="form-control" name="phone" id="form-phone-number" type="tel" required value="">
+              <label for="form-phone-number">Phone Number</label>
+              <span class="required-asterisk">*</span>
+            </div>
+
+            <div class="form-field">
+              <input class="form-control" name="email" id="form-email" type="email" required value="">
+              <label for="form-email">Email</label>
+              <span class="required-asterisk">*</span>
+            </div>
+
+            <div>
+              <input class="btn" type="submit" value="Get Shine Texts" ga-on="click" ga-event-category="SignUp"
+                ga-event-action="SMS" />
+            </div>
+          </form>
+          <div class="ctia">
+            Signing up means you agree to our <a href="/terms-of-service">Terms of Service</a>
+            & <a href="/privacy-policy">Privacy Policy</a> and to receive our daily message. Message & data rates may
+            apply.
+            Text STOP to opt-out, HELP for help.
           </div>
         </div>
-        <!-- end .container-signup -->
       </div>
-      <div class="col-md-5 homepage-header-image"></div>
-      <div class="section-arrow"></div>
+      <!-- end .container-signup -->
     </div>
+    <div class="col-md-5 homepage-header-image"></div>
+    <div class="section-arrow"></div>
+  </div>
 
-    <!-- How Shine Works -->
-    <div class="container-fluid how-shine-works">
+  <!-- How Shine Works -->
+  <div class="container-fluid how-shine-works">
 
-      <div class="product-description col-md-7 col-md-push-5">
-        <h2>How Shine Works</h2>
-        <ol data-bottom-top="transform: translateY(30%); opacity: 0.8;" data--150-bottom-center="transform: translateY(0%);" data--150-bottom-bottom="opacity: 1;">
-          <li>
-            <p>Sign up for Shine and you’ll receive a daily message Monday through Friday with quotes, research-backed articles,
-              actions you can take, and more to help you start your morning off right.</p>
-          </li>
-          <li>
-            <p>Get your unique referral code to share with friends. Refer 10 friends to unlock <a href="/referrals?utm_source=Shine&utm_medium=Home"
-                target="_blank" ga-on="click">swag</a> (hoodie: check, leggings: check check.).</p>
-          </li>
-          <li>
-            <p><strong>93% of people</strong> who have used Shine texts say that they are more confident and have seen a
-              noticeable improvement in their daily happiness.</p>
-          </li>
-        </ol>
+    <div class="product-description col-md-7 col-md-push-5">
+      <h2>How Shine Works</h2>
+      <ol data-bottom-top="transform: translateY(30%); opacity: 0.8;" data--150-bottom-center="transform: translateY(0%);"
+        data--150-bottom-bottom="opacity: 1;">
+        <li>
+          <p>Sign up for Shine and you’ll receive a daily message Monday through Friday with quotes, research-backed
+            articles,
+            actions you can take, and more to help you start your morning off right.</p>
+        </li>
+        <li>
+          <p>Get your unique referral code to share with friends. Refer 10 friends to unlock <a href="/referrals?utm_source=Shine&utm_medium=Home"
+              target="_blank" ga-on="click">swag</a> (hoodie: check, leggings: check check.).</p>
+        </li>
+        <li>
+          <p><strong>93% of people</strong> who have used Shine texts say that they are more confident and have seen a
+            noticeable improvement in their daily happiness.</p>
+        </li>
+      </ol>
 
-        <div class="border"></div>
-        <!-- Press -->
-        <div class="in-the-news col-xs-12 col-xs-offset-0 col-md-12 col-md-offset-0">
-          <div class="row">
-            <div class="news-item col-xs-12 col-sm-3">
-              <a href="https://news.fastcompany.com/can-an-app-eliminate-the-confidence-gap-4005790" target="_blank">
-                <img src="/images/news/fastco_logo.png">
-              </a>
-            </div>
-            <div class="news-item col-xs-12 col-sm-3">
-              <a href="http://motto.time.com/4381860/shine-app-millennial-women-data/" target="_blank">
-                <img class="time-logo" src="/images/news/time_logo.png">
-              </a>
-            </div>
-            <div class="news-item col-xs-12 col-sm-3">
-              <a href="http://mashable.com/2016/05/05/shine-texts/#z1I1WEfmBSqZ" target="_blank">
-                <img src="/images/news/mashable_logo.png">
-              </a>
-            </div>
-            <div class="news-item col-xs-12 col-sm-3">
-              <a href="https://www.glamour.com/inspired/blogs/the-conversation/2015/12/vacation-career-tips" target="_blank">
-                <img src="/images/news/glamour_logo.png">
-              </a>
-            </div>
-          </div>
-
-          <div class="row col-md-offset-0">
-            <div class="news-item col-xs-12 col-sm-6 col-md-6">
-              <a href="https://www.popsugar.com/career/Interview-Founders-Shine-Text-43439065" target="_blank">
-                <img class="pop-sugar-logo" src="/images/news/pop_sugar_logo.png">
-              </a>
-            </div>
-            <div class="news-item col-xs-12 col-sm-6 col-md-6">
-              <a href="http://hellogiggles.com/motivational-text-messaging-app-helps-me/" target="_blank">
-                <img class="hello-giggles-logo" src="/images/news/hello_giggles_logo.png">
-              </a>
-            </div>
-          </div>
-        </div><!-- end Press .in-the-news -->
-      </div>
-      <div class="product-image col-md-5 col-md-pull-7">
-        <img src="/images/homepage/shine-example-20180403.png">
-      </div>
-
-    </div>
-
-    <!-- App Container -->
-
-    <div class="container-fluid app-container">
-      <img class="app-section-oval" src="/images/homepage/Y-Inspire-Oval@2x.png" />
-      <img class="app-section-circle" src="/images/homepage/Y-Focus-Circle@2x.png" />
-      <div class="card-container">
-        <div class="card">
-          <p class="quote">I love receiving my daily Shine Texts! Every day it uplifts my mood and helps me to accept where
-            I'm at in my life.</p>
-          <div class="line"></div>
-          <p class="author">Alex F.</p>
-        </div>
-        <div class="card">
-          <p class="quote">Shine doesn't send me fluffy B.S. in the morning — they're real, straight-up texts about what's
-            going on in my life.</p>
-          <div class="line"></div>
-          <p class="author">Lilly Singh</p>
-        </div>
-        <div class="card">
-          <p class="quote">It's like having a best friend in my pocket that always knows just what I need to hear. Shine
-            Text helps me start my mornings off like a boss.</p>
-          <div class="line"></div>
-          <p class="author">Michelle L.</p>
-        </div>
-      </div>
-      <div class="info-container">
-        <div class="info">
-          <h2>Get the Shine app📱</h2>
-          <p>Upgrade your self-care routine with our iOS app, helping you grow one Shine Text or Shine Talk at a time.</p>
-          <div class="download-container">
-            <a class="download-button-link" href="https://go.onelink.me/Unhk?pid=Shine&c=Homepage">
-              <img class="download-button-img" src="/images/app-page/LaunchPage-AppleStoreBadge-Mobile.png" />
+      <div class="border"></div>
+      <!-- Press -->
+      <div class="in-the-news col-xs-12 col-xs-offset-0 col-md-12 col-md-offset-0">
+        <div class="row">
+          <div class="news-item col-xs-12 col-sm-3">
+            <a href="https://news.fastcompany.com/can-an-app-eliminate-the-confidence-gap-4005790" target="_blank">
+              <img src="/images/news/fastco_logo.png">
             </a>
-            <a class="download-android-link" href="/coming-soon-android">
-              <p class="download-android-text">
-                Looking For Android?
-                <img class="download-android-img" src="/images/app-page/LaunchPage-AndroidRobot.png" />
-              </p>
+          </div>
+          <div class="news-item col-xs-12 col-sm-3">
+            <a href="http://motto.time.com/4381860/shine-app-millennial-women-data/" target="_blank">
+              <img class="time-logo" src="/images/news/time_logo.png">
+            </a>
+          </div>
+          <div class="news-item col-xs-12 col-sm-3">
+            <a href="http://mashable.com/2016/05/05/shine-texts/#z1I1WEfmBSqZ" target="_blank">
+              <img src="/images/news/mashable_logo.png">
+            </a>
+          </div>
+          <div class="news-item col-xs-12 col-sm-3">
+            <a href="https://www.glamour.com/inspired/blogs/the-conversation/2015/12/vacation-career-tips" target="_blank">
+              <img src="/images/news/glamour_logo.png">
             </a>
           </div>
         </div>
-        <div class="app-image"></div>
-      </div>
-      <div class="section-arrow"></div>
+
+        <div class="row col-md-offset-0">
+          <div class="news-item col-xs-12 col-sm-6 col-md-6">
+            <a href="https://www.popsugar.com/career/Interview-Founders-Shine-Text-43439065" target="_blank">
+              <img class="pop-sugar-logo" src="/images/news/pop_sugar_logo.png">
+            </a>
+          </div>
+          <div class="news-item col-xs-12 col-sm-6 col-md-6">
+            <a href="http://hellogiggles.com/motivational-text-messaging-app-helps-me/" target="_blank">
+              <img class="hello-giggles-logo" src="/images/news/hello_giggles_logo.png">
+            </a>
+          </div>
+        </div>
+      </div><!-- end Press .in-the-news -->
+    </div>
+    <div class="product-image col-md-5 col-md-pull-7">
+      <img src="/images/homepage/shine-example-20180403.png">
     </div>
 
-    <%- partial ('partials/promoted-articles') %>
+  </div>
 
-      <%- partial ('partials/footer.ejs') %>
+  <!-- App Container -->
+
+  <div class="container-fluid app-container">
+    <img class="app-section-oval" src="/images/homepage/Y-Inspire-Oval@2x.png" />
+    <img class="app-section-circle" src="/images/homepage/Y-Focus-Circle@2x.png" />
+    <div class="card-container">
+      <div class="card">
+        <p class="quote">I love receiving my daily Shine Texts! Every day it uplifts my mood and helps me to accept
+          where
+          I'm at in my life.</p>
+        <div class="line"></div>
+        <p class="author">Alex F.</p>
+      </div>
+      <div class="card">
+        <p class="quote">Shine doesn't send me fluffy B.S. in the morning — they're real, straight-up texts about
+          what's
+          going on in my life.</p>
+        <div class="line"></div>
+        <p class="author">Lilly Singh</p>
+      </div>
+      <div class="card">
+        <p class="quote">It's like having a best friend in my pocket that always knows just what I need to hear. Shine
+          Text helps me start my mornings off like a boss.</p>
+        <div class="line"></div>
+        <p class="author">Michelle L.</p>
+      </div>
+    </div>
+    <div class="info-container">
+      <div class="info">
+        <h2>Get the Shine app📱</h2>
+        <p>Upgrade your self-care routine with our iOS app, helping you grow one Shine Text or Shine Talk at a time.</p>
+        <div class="download-container">
+          <a class="download-button-link" href="https://go.onelink.me/Unhk?pid=Shine&c=Homepage">
+            <img class="download-button-img" src="/images/app-page/LaunchPage-AppleStoreBadge-Mobile.png" />
+          </a>
+          <a class="download-android-link" href="/coming-soon-android">
+            <p class="download-android-text">
+              Looking For Android?
+              <img class="download-android-img" src="/images/app-page/LaunchPage-AndroidRobot.png" />
+            </p>
+          </a>
+        </div>
+      </div>
+      <div class="app-image"></div>
+    </div>
+    <div class="section-arrow"></div>
+  </div>
+
+  <%- partial ('partials/promoted-articles') %>
+
+  <%- partial ('partials/footer.ejs') %>
 
 </div> <!-- end div class="homepage" -->
 


### PR DESCRIPTION
#### What's this PR do?
- Most of the changes are due to prettier reformatting the code...
- Add app CTA button to before signup form on homepage
- Add styling to button
- Change copy in homepage header from 'A morning self-care text to help you run the day' to 'A morning self-care reminder to help you run the day.'

#### How was this tested? How should this be reviewed?
- reviewed locally

#### What are the relevant tickets?
- https://trello.com/c/55Jvx1ls/326-optimize-shinetextcom-on-mobile-web-to-feature-app-cta-higher

#### Questions / Considerations
