### PR TITLE
Remove GA properties around button in signup form 

### DIFF
--- a/api/services/partnersData.js
+++ b/api/services/partnersData.js
@@ -256,7 +256,7 @@ const partnersData = {
     campaignKey: 'OPC242EB5AF6EFE8477E4BEC73301BA67F',
     alphaEmailRequired: true,
     customDisclaimer:
-      'Signing up means you agree to our <a href="/terms-of-service">Terms of Service</a> & <a href="/privacy-policy">Privacy Policy</a> and to receive our daily messages and the daily Skimm email from our partner. Message & data rates may apply. Text STOP to opt-out, HELP for help.',
+      'Signing up means you agree to our <a href="/terms-of-service">Terms of Service</a> & <a href="/privacy-policy">Privacy Policy</a> and to receive our daily text messages and Shine email newsletters. Message & data rates may apply. Text STOP to opt-out, HELP for help.',
     signUpButtonText: 'Text me the link!',
   },
 };

--- a/views/components/SignUpForm.js
+++ b/views/components/SignUpForm.js
@@ -74,10 +74,6 @@ const SignUpForm = props => {
             class="btn"
             type="submit"
             value={signUpButtonText || 'Get Shine Texts'}
-            ga-on="click"
-            ga-event-category="SignUp"
-            ga-event-action="SMS"
-            ga-event-label={partnerId}
           />
         </div>
       </form>


### PR DESCRIPTION
#### What’s this PR do?
- Remove GA properties around button in signup form. This event will be tracked through GTM (google tag manager)

#### How was this tested? How should this be reviewed?
- tested in staging (signup on form & get text & user is updated)

#### What are the relevant tickets?
- https://trello.com/c/rGc2kXNR/328-create-new-landing-page-for-fb-ads-to-send-a-text-to-download-the-app

#### Questions / Considerations
~~❗️ Existing users can get this text. Is this okay?~~
~~❌ Need to have copy checked prior to launching~~
