### PR TITLE
Add vanity URL to redirect users from homepage to promo page

### DIFF
--- a/api/controllers/WebViewController.js
+++ b/api/controllers/WebViewController.js
@@ -68,6 +68,36 @@ module.exports = {
     return res.redirect(301, sails.config.globals.dailyShineBaseUrl);
   },
 
+  /**
+   * Redirect to specific podcast promo page
+   */
+  podcastPromoRedirect: (req, res) => {
+    const podcastDirectories = {
+      molls: 'podcast-plzadvise',
+      boost: 'podcast-dailyboost',
+      dst: 'podcast-dietstartstomorrow',
+      friendzone: 'podcast-friendzone',
+      forever35: 'podcast-forever35',
+      heygirl: 'podcast-heygirl',
+      hollywood: 'podcast-happierinhollywood',
+      jvn: 'podcast-jvn',
+      happiness: 'podcast-scienceofhappiness',
+      glowingup: 'podcast-glowingup',
+      smalldoses: 'podcast-smalldoses',
+      happier: 'podcast-gretchenrubin',
+      ladygang: 'podcast-ladygang',
+      prettybasic: 'podcast-prettybasic',
+      zigzag: 'podcast-zigzag',
+    };
+
+    let originalName = req.url.split('/')[1];
+    let redirectName = podcastDirectories[originalName];
+    return res.redirect(
+      301,
+      `${sails.config.globals.premiumShineBaseUrl}/promo/${redirectName}`
+    );
+  },
+
   ////////////////////////////////////////////////////////////////////////////
 
   squad: (req, res) => {

--- a/config/routes.js
+++ b/config/routes.js
@@ -116,6 +116,23 @@ var routes = {
     },
   },
 
+  // PODCAST PROMO REDIRECTS
+  '/molls': 'WebViewController.podcastPromoRedirect',
+  '/boost': 'WebViewController.podcastPromoRedirect',
+  '/dst': 'WebViewController.podcastPromoRedirect',
+  '/friendzone': 'WebViewController.podcastPromoRedirect',
+  '/forever35': 'WebViewController.podcastPromoRedirect',
+  '/heygirl': 'WebViewController.podcastPromoRedirect',
+  '/hollywood': 'WebViewController.podcastPromoRedirect',
+  '/jvn': 'WebViewController.podcastPromoRedirect',
+  '/happiness': 'WebViewController.podcastPromoRedirect',
+  '/glowingup': 'WebViewController.podcastPromoRedirect',
+  '/smalldoses': 'WebViewController.podcastPromoRedirect',
+  '/happier': 'WebViewController.podcastPromoRedirect',
+  '/ladygang': 'WebViewController.podcastPromoRedirect',
+  '/prettybasic': 'WebViewController.podcastPromoRedirect',
+  '/zigzag': 'WebViewController.podcastPromoRedirect',
+
   /***************************************************************************
    *                                                                          *
    * Custom routes here...                                                    *


### PR DESCRIPTION
#### What's this PR do?
- Create redirect from our homepage to specific podcast promo page

#### How was this tested? How should this be reviewed?
- tested locally 

#### What are the relevant tickets?
- Requested in this slack convo: https://shine-team.slack.com/archives/CCV4QMJ5T/p1546450914006900

#### Questions / Considerations
Additional context needed or things to consider
