### PR TITLE
Prevent app page redirect when users come from a referral link

### DIFF
--- a/api/controllers/WebViewController.js
+++ b/api/controllers/WebViewController.js
@@ -36,8 +36,27 @@ module.exports = {
   /**
    * Redirect to the Shine Premium (web conversion) landing page.
    */
-  app: (req, res) => {
-    return res.redirect(301, sails.config.globals.premiumShineBaseUrl);
+  app: function(req, res) {
+    // @todo To support SMS referrals, we'll continue serving the old homepage
+    // to users who come in from a referral link. Will eventually need another
+    // solution for referrals to work with the app download page too.
+    if (req.query.r) {
+      return this.home(req, res);
+    }
+
+    // Make sure to pass the query string on through the redirect.
+    let query = '';
+    if (req.query) {
+      query += '?';
+      query += Object.entries(req.query)
+        .map(([key, val]) => `${key}=${encodeURIComponent(val)}`)
+        .join('&');
+    }
+
+    return res.redirect(
+      301,
+      `${sails.config.globals.premiumShineBaseUrl}${query}`
+    );
   },
 
   /**


### PR DESCRIPTION
#### What's this PR do?
Serves the old homepage if a visit's come from the legacy referral links. Also making sure that we're passing on query params through the app page redirect.

We don't have a great way of handling SMS referrals with the new pages or platforms right now. So until we get there, allow for users to still get referrals the original way.

#### How was this tested?
Tested a couple URLs locally:
- `/`: redirected
- `/?r=abc123`: no redirect, old homepage
- `/?testQuery=testValue&r=abc123`: no redirect, old homepage
- `/?testQuery=testValue&testQuery2=testValue2`: redirected with query params