### PR TITLE
Adds /gohome path redirect

### DIFF
--- a/api/controllers/WebViewController.js
+++ b/api/controllers/WebViewController.js
@@ -16,21 +16,51 @@ import CampaignApp from '../../views/components/campaigns/CampaignApp';
 import CampaignReferral from '../../views/components/campaigns/CampaignReferral';
 Promise.promisifyAll(request);
 
+/**
+ * Parses the query object and returns a string that we'll use to pass on the
+ * values through the redirect.
+ *
+ * @param {object} query
+ * @return {string}
+ */
+function compileQueryToString(query) {
+  let result = '';
+  if (query && Object.entries(query).length > 0) {
+    result += '?';
+    result += Object.entries(query)
+      .map(([key, val]) => `${key}=${encodeURIComponent(val)}`)
+      .join('&');
+  }
+
+  return result;
+}
+
+/**
+ * Helper method for a 301 redirect that includes passing on any url queries.
+ *
+ * @param {string} url
+ * @param {object} req
+ * @param {object} res
+ * @return res.redirect()
+ */
+function redirectWithQueries(path, req, res) {
+  return res.redirect(301, `${path}${compileQueryToString(req.query)}`);
+}
+
 module.exports = {
   ////////////////////////////// Redirects ///////////////////////////////////
-
   /**
    * Redirect to the advice page.
    */
   advice: (req, res) => {
-    return res.redirect(301, sails.config.globals.adviceBaseUrl);
+    return redirectWithQueries(sails.config.globals.adviceBaseUrl, req, res);
   },
 
   /**
    * Redirect to the homepage now that Android has launched.
    */
   androidSignUp: function(req, res) {
-    return res.redirect(301, '/');
+    return redirectWithQueries('/', req, res);
   },
 
   /**
@@ -44,18 +74,10 @@ module.exports = {
       return this.home(req, res);
     }
 
-    // Make sure to pass the query string on through the redirect.
-    let query = '';
-    if (req.query) {
-      query += '?';
-      query += Object.entries(req.query)
-        .map(([key, val]) => `${key}=${encodeURIComponent(val)}`)
-        .join('&');
-    }
-
-    return res.redirect(
-      301,
-      `${sails.config.globals.premiumShineBaseUrl}${query}`
+    return redirectWithQueries(
+      sails.config.globals.premiumShineBaseUrl,
+      req,
+      res
     );
   },
 
@@ -64,37 +86,46 @@ module.exports = {
    * a link and don't specify the subdomain, we can try to fix that here.
    */
   articlesRedirect: (req, res) => {
-    return res.redirect(301, `${sails.config.globals.adviceBaseUrl}${req.url}`);
+    return redirectWithQueries(
+      `${sails.config.globals.adviceBaseUrl}${req.url}`,
+      req,
+      res
+    );
   },
 
   careers: (req, res) => {
-    return res.redirect(301, '/jobs');
+    return redirectWithQueries('/jobs', req, res);
   },
 
   gift: (req, res) => {
-    return res.redirect(
-      301,
-      `${sails.config.globals.premiumShineBaseUrl}/gift`
+    return redirectWithQueries(
+      `${sails.config.globals.premiumShineBaseUrl}/gift`,
+      req,
+      res
     );
   },
 
   gohome: (req, res) => {
-    return res.redirect(301, `https://gohome.shinetext.com`);
+    return redirectWithQueries(`https://gohome.shinetext.com`, req, res);
   },
 
   nod: (req, res) => {
-    return res.redirect(301, '/p/nod');
+    return redirectWithQueries(`/p/nod`, req, res);
   },
 
   jobs: (req, res) => {
-    return res.redirect(302, `${sails.config.globals.jobsRedirectUrl}`);
+    return redirectWithQueries(sails.config.globals.jobsRedirectUrl, req, res);
   },
 
   /**
    * Redirect to the Daily Shine homepage.
    */
   daily: (req, res) => {
-    return res.redirect(301, sails.config.globals.dailyShineBaseUrl);
+    return redirectWithQueries(
+      sails.config.globals.dailyShineBaseUrl,
+      req,
+      res
+    );
   },
 
   /**

--- a/api/controllers/WebViewController.js
+++ b/api/controllers/WebViewController.js
@@ -78,6 +78,10 @@ module.exports = {
     );
   },
 
+  gohome: (req, res) => {
+    return res.redirect(301, `https://gohome.shinetext.com`);
+  },
+
   nod: (req, res) => {
     return res.redirect(301, '/p/nod');
   },

--- a/config/routes.js
+++ b/config/routes.js
@@ -56,6 +56,7 @@ var routes = {
     },
   },
   '/gift': 'WebViewController.gift',
+  '/gohome': 'WebViewController.gohome',
   '/home': 'WebViewController.app',
   '/jobs': 'WebViewController.jobs',
   '/nod': 'WebViewController.nod',


### PR DESCRIPTION
#### What's this PR do?
When people go to shinetext.com/gohome, they'll be redirected to our `gohome` subdomain.

I opted to just hardcode this value in here as opposed to placing it behind an env var because it's not going to change, it's not a secret value, and to not add an extra abstraction.

#### What are the relevant tickets?
https://shinetext.atlassian.net/browse/SHI-1195
