### PR TITLE
Redirecting traffic with ?r=sms

### DIFF
--- a/api/controllers/WebViewController.js
+++ b/api/controllers/WebViewController.js
@@ -70,7 +70,10 @@ module.exports = {
     // @todo To support SMS referrals, we'll continue serving the old homepage
     // to users who come in from a referral link. Will eventually need another
     // solution for referrals to work with the app download page too.
-    if (req.query.r) {
+    //
+    // UPDATE: excluding ?r=sms. It's not a real referral code and it's showing
+    // up in search results, where we'd rather forward people onto the app.
+    if (req.query.r && req.query.r !== 'sms') {
       return this.home(req, res);
     }
 


### PR DESCRIPTION
#### What's this PR do?
If you Google search for "shine text" you'll get a link to our homepage with `/?r=sms`. This was a side door we left open for people to still sign up for SMS.

While people can still get referrals from sharing with people who sign up on SMS, we're going to close this for any organic web traffic to go to the app isntead

#### How was this tested? How should this be reviewed?
Local testing with:
- `localhost:1337/` = redirect
- `/?r=sms` = redirect
- `/?r=abc123` = renders old homepage