### PR TITLE
Adds redirects and nav items for virusanxiety site

### DIFF
--- a/api/controllers/WebViewController.js
+++ b/api/controllers/WebViewController.js
@@ -253,6 +253,10 @@ module.exports = {
     );
   },
 
+  virusanxiety: (req, res) => {
+    return redirectWithQueries(`https://virusanxiety.com`, req, res);
+  },
+
   /**
    * Display /confirmation view and pass along any query params.
    */

--- a/config/routes.js
+++ b/config/routes.js
@@ -59,6 +59,7 @@ var routes = {
   '/nod': 'WebViewController.nod',
   '/quiz': 'WebViewController.quiz',
   '/p/:partner': 'WebViewController.partners',
+  '/pandemic-self-care-toolkit': 'WebViewController.virusanxiety',
   '/partners/:partner': 'WebViewController.partners',
   '/privacy-policy': {
     view: 'privacy-policy',
@@ -108,6 +109,7 @@ var routes = {
       layout: 'layouts/subpage.layout',
     },
   },
+  '/virusanxiety': 'WebViewController.virusanxiety',
   '/year1': {
     view: 'year1',
     locals: {

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -36,6 +36,7 @@
     </div>
     <div class="page-links">
       <a href="/">Join Shine</a>
+      <a href="/virusanxiety">Coronavirus Anxiety</a>
       <a
         href="https://premium.shinetext.com/quiz/start?utm_source=Shine&utm_medium=WebMain&utm_campaign=Footer"
         >Self-Care Style Quiz</a

--- a/views/partials/footer.ejs
+++ b/views/partials/footer.ejs
@@ -36,7 +36,10 @@
     </div>
     <div class="page-links">
       <a href="/">Join Shine</a>
-      <a href="/virusanxiety">Coronavirus Anxiety</a>
+      <a
+        href="/virusanxiety?utm_source=Shine&utm_medium=WebMain&utm_campaign=Footer"
+        >Coronavirus Anxiety</a
+      >
       <a
         href="https://premium.shinetext.com/quiz/start?utm_source=Shine&utm_medium=WebMain&utm_campaign=Footer"
         >Self-Care Style Quiz</a

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -9,7 +9,10 @@
   <div class="navbar-links-container">
     <div class="navbar-links"><a href="/">Shine Premium</a></div>
     <div class="navbar-links">
-      <a href="/virusanxiety">Coronavirus Anxiety</a>
+      <a
+        href="/virusanxiety?utm_source=Shine&utm_medium=WebMain&utm_campaign=Top_Nav"
+        >Coronavirus Anxiety</a
+      >
     </div>
     <div class="navbar-links"><a href="/advice">Get Advice</a></div>
     <div class="navbar-links"><a href="/squad">The Squad</a></div>
@@ -20,7 +23,12 @@
   <i id="mobile-menu-button-close" class="fa fa-times" aria-hidden="true"></i>
   <ul>
     <li><a href="/">Shine Premium</a></li>
-    <li><a href="/virusanxiety">Coronavirus Anxiety</a></li>
+    <li>
+      <a
+        href="/virusanxiety?utm_source=Shine&utm_medium=WebMain&utm_campaign=Top_Nav"
+        >Coronavirus Anxiety</a
+      >
+    </li>
     <li><a href="/advice">Get Advice</a></li>
     <li><a href="/squad">The Squad</a></li>
   </ul>

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -8,6 +8,9 @@
 
   <div class="navbar-links-container">
     <div class="navbar-links"><a href="/">Shine Premium</a></div>
+    <div class="navbar-links">
+      <a href="/virusanxiety">Coronavirus Anxiety</a>
+    </div>
     <div class="navbar-links"><a href="/advice">Get Advice</a></div>
     <div class="navbar-links"><a href="/squad">The Squad</a></div>
   </div>
@@ -17,6 +20,7 @@
   <i id="mobile-menu-button-close" class="fa fa-times" aria-hidden="true"></i>
   <ul>
     <li><a href="/">Shine Premium</a></li>
+    <li><a href="/virusanxiety">Coronavirus Anxiety</a></li>
     <li><a href="/advice">Get Advice</a></li>
     <li><a href="/squad">The Squad</a></li>
   </ul>


### PR DESCRIPTION
#### What's this PR do?
Links added to header and footer that redirect to virusanxiety.com.

Including a redirect for `/pandemic-self-care-toolkit` since that's what got committed to the link that'll be in the app (https://github.com/shinetext/glow/pull/1269).

We should not push this to production/`master` until the other site is published.

#### How was this tested?
Local testing on the privacy-policy page since the homepage redirects