### PR TITLE
Removes support for SMS signup page

### DIFF
--- a/api/controllers/WebViewController.js
+++ b/api/controllers/WebViewController.js
@@ -67,16 +67,6 @@ module.exports = {
    * Redirect to the Shine Premium (web conversion) landing page.
    */
   app: function(req, res) {
-    // @todo To support SMS referrals, we'll continue serving the old homepage
-    // to users who come in from a referral link. Will eventually need another
-    // solution for referrals to work with the app download page too.
-    //
-    // UPDATE: excluding ?r=sms. It's not a real referral code and it's showing
-    // up in search results, where we'd rather forward people onto the app.
-    if (req.query.r && req.query.r !== 'sms') {
-      return this.home(req, res);
-    }
-
     return redirectWithQueries(
       sails.config.globals.premiumShineBaseUrl,
       req,


### PR DESCRIPTION
### What's this PR do?
People were previously able to get to our old SMS sign up page if they came through a referral url like `shinetext.com/?r=abc123`. This removes support for that and will now just redirect to our primary home page for the app.

### How was this tested?
Local testing to the home url with `/?r=abc123`

### Why are we doing this?
Apparently people are still finding ways to share their old referral url: https://shine-team.slack.com/archives/C09BF93CG/p1585843066000200