### PR TITLE
New /podcast and /invite redirects

### DIFF
--- a/api/controllers/WebViewController.js
+++ b/api/controllers/WebViewController.js
@@ -198,7 +198,6 @@ module.exports = {
       who: `whoweekly?${utmSourceVeritone}&${utmMedium}&utm_campaign=Who_Weekly`,
       zigzag: `zigzag?${utmSourceVeritone}&${utmMedium}&utm_campaign=Zigzag`,
       spotify: `spotify?utm_source=spotify&utm_medium=podcast&utm_campaign=Feb2020`,
-      podcast: `podcast?utm_source=Shine&utm_medium=podcast&utm_campaign=Podcast_CTA`,
       anxiety: `podcast-anxiety?utm_source=Shine&utm_medium=podcast&utm_campaign=Podcast_CTA_AnxietySeries`,
       20: `podcast-20-sale?utm_source=Shine&utm_medium=podcast&utm_campaign=Podcast_CTA_20Sale`,
     };
@@ -248,6 +247,22 @@ module.exports = {
 
   virusanxiety: (req, res) => {
     return redirectWithQueries(`https://virusanxiety.com`, req, res);
+  },
+
+  podcast: (req, res) => {
+    return redirectWithQueries(
+      `https://join.shinetext.com/?utm_source=Shine&utm_medium=podcast&utm_campaign=Podcast_CTA`,
+      req,
+      res
+    );
+  },
+
+  invite: (req, res) => {
+    return redirectWithQueries(
+      `https://join.shinetext.com/promo/invite-friends/?utm_source=Shine&utm_medium=IG_Stories&utm_campaign=InviteFriends`,
+      req,
+      res
+    );
   },
 
   /**

--- a/config/routes.js
+++ b/config/routes.js
@@ -53,6 +53,7 @@ var routes = {
   '/dreamforce': 'WebViewController.dreamforce',
   '/faq': 'WebViewController.faq',
   '/gift': 'WebViewController.gift',
+  '/invite': 'WebViewController.invite',
   '/mentalhealthbreak': 'WebViewController.mentalhealthbreak',
   '/home': 'WebViewController.app',
   '/jobs': 'WebViewController.jobs',
@@ -61,6 +62,7 @@ var routes = {
   '/p/:partner': 'WebViewController.partners',
   '/pandemic-self-care-toolkit': 'WebViewController.virusanxiety',
   '/partners/:partner': 'WebViewController.partners',
+  '/podcast': 'WebViewController.podcast',
   '/privacy-policy': {
     view: 'privacy-policy',
     locals: {


### PR DESCRIPTION
#### What's this PR do?
- Updated /podcast redirect to go to homepage with utm params.
- New /invite redirect for a vanity URL that will go into IG stories when sharing the app.

#### How was this tested? How should this be reviewed?
Because these weren't like the promo page redirects, I wasn't able to see the redirect on my local...would like help on how to test this!