### PR TITLE
Redirect users to election quiz

### DIFF
--- a/api/controllers/WebViewController.js
+++ b/api/controllers/WebViewController.js
@@ -179,6 +179,17 @@ module.exports = {
   },
 
   /**
+   * Redirect to 2020 election + shine quiz.
+   */
+  election: (req, res) => {
+    return redirectWithQueries(
+      `https://theshineapp.com/quiz/start?partner=election`,
+      req,
+      res
+    );
+  },
+
+  /**
    * Redirect to specific promo page
    */
   promoRedirect: (req, res) => {

--- a/config/routes.js
+++ b/config/routes.js
@@ -65,6 +65,7 @@ var routes = {
   '/partners/:partner': 'WebViewController.partners',
   '/podcast': 'WebViewController.podcast',
   '/mealtime': 'WebViewController.mealtime',
+  '/2020-election': 'WebViewController.election',
   '/privacy-policy': {
     view: 'privacy-policy',
     locals: {


### PR DESCRIPTION
#### What's this PR do?
Support vanity URL `/2020-election`. Redirect all users to the quiz landing page. 

#### How was this tested? How should this be reviewed?
Tested by visiting `localhost:1337/2020-election`

#### What are the relevant tickets?
https://shinetext.atlassian.net/secure/RapidBoard.jspa?rapidView=1&projectKey=SHI&modal=detail&selectedIssue=SHI-2262
